### PR TITLE
fix: Ning Ding 统一命名 + 精选文章补为 3 篇

### DIFF
--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -5,7 +5,7 @@ import { NewsletterForm } from "@/components/ui/NewsletterForm";
 export const metadata: Metadata = {
   title: "关于我",
   description:
-    "Neil Ding，异乡好居副总裁，dingning.ai 创始人。白天推动 AI 在国际教育行业的落地，晚上用 Vibe Coding 亲手构建产品。",
+    "Ning Ding，异乡好居副总裁，dingning.ai 创始人。白天推动 AI 在国际教育行业的落地，晚上用 Vibe Coding 亲手构建产品。",
 };
 
 const timeline = [
@@ -44,7 +44,7 @@ export default function AboutPage() {
             <div className="w-32 h-32 rounded-full bg-[var(--bg-tertiary)] border border-[var(--border)] overflow-hidden">
               <Image
                 src="/images/neil-ding-placeholder.svg"
-                alt="Neil Ding"
+                alt="Ning Ding"
                 width={128}
                 height={128}
                 className="w-full h-full object-cover"
@@ -53,7 +53,7 @@ export default function AboutPage() {
           </div>
           <div className="text-center md:text-left">
             <h1 className="text-3xl md:text-4xl font-semibold text-[var(--text-primary)] mb-4">
-              Neil Ding
+              Ning Ding
             </h1>
             <p className="text-base text-[var(--text-secondary)] leading-relaxed">
               异乡好居副总裁，dingning.ai 创始人。负责留学渠道部，维护超过 3 万名合作伙伴；

--- a/app/blog/[slug]/page.tsx
+++ b/app/blog/[slug]/page.tsx
@@ -54,7 +54,7 @@ export default function BlogPost({ params }: Props) {
             {post.meta.title}
           </h1>
           <div className="flex items-center gap-3 text-sm text-[var(--text-muted)]">
-            <span>Neil Ding</span>
+            <span>Ning Ding</span>
             <span>·</span>
             <time dateTime={post.meta.date}>{post.meta.date}</time>
             <span>·</span>

--- a/app/blog/page.tsx
+++ b/app/blog/page.tsx
@@ -4,7 +4,7 @@ import { getAllPosts } from "@/lib/mdx";
 
 export const metadata: Metadata = {
   title: "Blog",
-  description: "Neil Ding 的 AI 实践、Vibe Coding 实录与国际教育行业思考。",
+  description: "Ning Ding 的 AI 实践、Vibe Coding 实录与国际教育行业思考。",
 };
 
 export default function BlogPage() {

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -12,13 +12,13 @@ const inter = Inter({
 
 export const metadata: Metadata = {
   title: {
-    default: "Neil Ding - dingning.ai",
-    template: "%s | Neil Ding - dingning.ai",
+    default: "Ning Ding - dingning.ai",
+    template: "%s | Ning Ding - dingning.ai",
   },
   description:
     "我不会写代码，但我用 AI 构建了三款产品。异乡好居副总裁，dingning.ai 创始人，Vibe Coder。",
   openGraph: {
-    title: "Neil Ding - dingning.ai",
+    title: "Ning Ding - dingning.ai",
     description:
       "一个国际教育老兵的 AI 实验场。白天管业务，晚上写产品。",
     url: "https://dingning.ai",
@@ -28,7 +28,7 @@ export const metadata: Metadata = {
   },
   twitter: {
     card: "summary_large_image",
-    title: "Neil Ding - dingning.ai",
+    title: "Ning Ding - dingning.ai",
     description:
       "一个国际教育老兵的 AI 实验场。白天管业务，晚上写产品。",
   },

--- a/app/projects/page.tsx
+++ b/app/projects/page.tsx
@@ -3,7 +3,7 @@ import { ExternalLink } from "lucide-react";
 
 export const metadata: Metadata = {
   title: "Projects",
-  description: "Neil Ding 构建和推动的项目：异乡好居、异乡缴费、异乡人才。",
+  description: "Ning Ding 构建和推动的项目：异乡好居、异乡缴费、异乡人才。",
 };
 
 const projects = [

--- a/components/layout/Footer.tsx
+++ b/components/layout/Footer.tsx
@@ -11,7 +11,7 @@ export function Footer() {
       <div className="max-w-6xl mx-auto px-4 md:px-6 lg:px-8 py-12">
         <div className="flex flex-col md:flex-row items-center justify-between gap-6">
           <div className="text-sm text-[var(--text-muted)]">
-            © {new Date().getFullYear()} Neil Ding · dingning.ai
+            © {new Date().getFullYear()} Ning Ding · dingning.ai
           </div>
 
           <div className="flex items-center gap-4">

--- a/components/layout/Header.tsx
+++ b/components/layout/Header.tsx
@@ -23,7 +23,7 @@ export function Header() {
             href="/"
             className="text-xl font-semibold text-[var(--text-primary)] tracking-tight"
           >
-            Neil Ding
+            Ning Ding
           </Link>
 
           {/* Desktop nav */}

--- a/components/sections/AboutBrief.tsx
+++ b/components/sections/AboutBrief.tsx
@@ -10,7 +10,7 @@ export function AboutBrief() {
             关于我
           </h2>
           <p className="text-base text-[var(--text-secondary)] leading-relaxed mb-4">
-            我是 Neil Ding，异乡好居副总裁，同时也是 dingning.ai 这个一人公司的创始人。
+            我是 Ning Ding，异乡好居副总裁，同时也是 dingning.ai 这个一人网站的创始人。
             异乡好居服务全球留学生的海外住宿预订，累计服务超过
             <span className="font-medium text-[var(--text-primary)]"> 40 万</span>名客户，
             目的地超过

--- a/components/sections/HeroSection.tsx
+++ b/components/sections/HeroSection.tsx
@@ -11,7 +11,7 @@ export function HeroSection() {
             <div className="w-40 h-40 md:w-52 md:h-52 rounded-full bg-[var(--bg-tertiary)] border border-[var(--border)] overflow-hidden">
               <Image
                 src="/images/neil-ding-placeholder.svg"
-                alt="Neil Ding"
+                alt="Ning Ding"
                 width={208}
                 height={208}
                 priority
@@ -28,7 +28,7 @@ export function HeroSection() {
               但我用 AI 构建了三款产品
             </h1>
             <p className="text-base md:text-lg text-[var(--text-secondary)] max-w-xl leading-relaxed">
-              Neil Ding · 异乡好居副总裁 · dingning.ai 创始人
+              Ning Ding · 异乡好居副总裁 · dingning.ai 创始人
               <br className="hidden md:block" />
               白天推动 AI 在国际教育行业的落地，晚上用 Vibe Coding 亲手构建产品。
             </p>

--- a/content/blog/2026-02-28-recommendation-engine-architecture.mdx
+++ b/content/blog/2026-02-28-recommendation-engine-architecture.mdx
@@ -4,7 +4,7 @@ date: "2026-02-28"
 excerpt: "我不是工程师，但我用 AI 构建了一个四层推荐引擎：Redis 缓存 → pgvector 向量召回 → 规则打分 → LLM 重排序。这是我做的每一个架构决策和背后的思考。"
 tags: [Vibe Coding, AI, 技术实录]
 published: true
-featured: false
+featured: true
 ---
 
 ## 背景


### PR DESCRIPTION
## Summary
- 全局 Neil Ding → Ning Ding（Header、Footer、Hero、About、Blog、Projects、layout metadata）
- 「一人公司」→「一人网站」
- 推荐引擎文章设为 featured，首页精选恢复为 3 篇

## Test plan
- [ ] Header 左上角显示 Ning Ding
- [ ] 首页精选文章显示 3 篇
- [ ] 全站无 Neil Ding 残留

🤖 Generated with [Claude Code](https://claude.com/claude-code)