### PR TITLE
fix: 修复 MDX 表格在移动端溢出问题

### DIFF
--- a/app/blog/[slug]/page.tsx
+++ b/app/blog/[slug]/page.tsx
@@ -3,6 +3,7 @@ import { notFound } from "next/navigation";
 import { MDXRemote } from "next-mdx-remote/rsc";
 import { getAllPosts, getPostBySlug } from "@/lib/mdx";
 import { NewsletterForm } from "@/components/ui/NewsletterForm";
+import { mdxComponents } from "@/components/mdx/MdxComponents";
 
 export const revalidate = 3600;
 
@@ -64,7 +65,7 @@ export default function BlogPost({ params }: Props) {
 
         {/* Content */}
         <div className="prose">
-          <MDXRemote source={post.content} />
+          <MDXRemote source={post.content} components={mdxComponents} />
         </div>
 
         {/* Newsletter CTA */}

--- a/components/mdx/MdxComponents.tsx
+++ b/components/mdx/MdxComponents.tsx
@@ -1,0 +1,14 @@
+import type { MDXComponents } from "mdx/types";
+import type { ComponentPropsWithoutRef } from "react";
+
+function Table(props: ComponentPropsWithoutRef<"table">) {
+  return (
+    <div className="overflow-x-auto">
+      <table {...props} />
+    </div>
+  );
+}
+
+export const mdxComponents: MDXComponents = {
+  table: Table,
+};


### PR DESCRIPTION
## Summary
- 新增自定义 MDX 组件，为 `<table>` 包裹 `overflow-x-auto` 容器
- 修改博客文章页引用自定义组件，确保表格在窄屏可横向滚动

## Test plan
- [ ] 在移动端访问含表格的文章（如「一个非程序员，如何用 AI 从零搭建个人网站」），确认表格可横向滚动
- [ ] 在桌面端确认表格显示无变化

🤖 Generated with [Claude Code](https://claude.com/claude-code)