### PR TITLE
feat: C-01 色彩系统扩展 + A-03 三页面数字去重

### DIFF
--- a/__tests__/components/AboutBrief.test.tsx
+++ b/__tests__/components/AboutBrief.test.tsx
@@ -1,0 +1,33 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+
+vi.mock("next/link", () => ({
+  default: ({ children, href, ...props }: { children: React.ReactNode; href: string; [key: string]: unknown }) => (
+    <a href={href} {...props}>{children}</a>
+  ),
+}));
+
+import { AboutBrief } from "@/components/sections/AboutBrief";
+
+describe("AboutBrief (A-03 dedup)", () => {
+  it("does NOT contain raw business numbers that belong on About page", () => {
+    render(<AboutBrief />);
+    const html = document.body.innerHTML;
+    // These specific numbers should only appear on About page, not homepage
+    expect(html).not.toContain("40 万");
+    expect(html).not.toContain("75 亿");
+    expect(html).not.toContain("27 个国家");
+    expect(html).not.toContain("18 万");
+  });
+
+  it("focuses on positioning and mission", () => {
+    render(<AboutBrief />);
+    expect(screen.getByText(/AI 提升工作效率/)).toBeInTheDocument();
+  });
+
+  it("links to about page", () => {
+    render(<AboutBrief />);
+    const link = screen.getByText("了解完整经历");
+    expect(link.closest("a")).toHaveAttribute("href", "/about");
+  });
+});

--- a/__tests__/components/ColorSystem.test.tsx
+++ b/__tests__/components/ColorSystem.test.tsx
@@ -1,0 +1,60 @@
+import { describe, it, expect } from "vitest";
+import fs from "fs";
+import path from "path";
+
+describe("Color System (C-01)", () => {
+  const cssContent = fs.readFileSync(
+    path.join(process.cwd(), "app/globals.css"),
+    "utf-8"
+  );
+  const tailwindConfig = fs.readFileSync(
+    path.join(process.cwd(), "tailwind.config.ts"),
+    "utf-8"
+  );
+
+  it("defines CTA color variables in globals.css", () => {
+    expect(cssContent).toContain("--cta:");
+    expect(cssContent).toContain("--cta-light:");
+  });
+
+  it("CTA color is different from accent color", () => {
+    const accentMatch = cssContent.match(/--accent:\s*(#[0-9A-Fa-f]+)/);
+    const ctaMatch = cssContent.match(/--cta:\s*(#[0-9A-Fa-f]+)/);
+    expect(accentMatch).not.toBeNull();
+    expect(ctaMatch).not.toBeNull();
+    expect(accentMatch![1]).not.toBe(ctaMatch![1]);
+  });
+
+  it("tailwind config includes cta color mapping", () => {
+    expect(tailwindConfig).toContain("cta:");
+    expect(tailwindConfig).toContain("var(--cta)");
+    expect(tailwindConfig).toContain("var(--cta-light)");
+  });
+
+  it("Newsletter button uses CTA color, not accent", () => {
+    const formContent = fs.readFileSync(
+      path.join(process.cwd(), "components/ui/NewsletterForm.tsx"),
+      "utf-8"
+    );
+    expect(formContent).toContain("--cta");
+    expect(formContent).not.toMatch(/bg-\[var\(--accent\)\]/);
+  });
+
+  it("Header CTA button uses CTA color, not accent", () => {
+    const headerContent = fs.readFileSync(
+      path.join(process.cwd(), "components/layout/Header.tsx"),
+      "utf-8"
+    );
+    // The "联系我" button should use CTA color
+    expect(headerContent).toContain("--cta");
+  });
+
+  it("Blog tag filters still use accent color (informational)", () => {
+    const blogListContent = fs.readFileSync(
+      path.join(process.cwd(), "components/ui/BlogList.tsx"),
+      "utf-8"
+    );
+    expect(blogListContent).toContain("--accent");
+    expect(blogListContent).not.toContain("--cta");
+  });
+});

--- a/app/globals.css
+++ b/app/globals.css
@@ -13,9 +13,13 @@
   --text-secondary:#4B5563;
   --text-muted:    #9CA3AF;
 
-  /* 强调色 */
+  /* 强调色（信息型：链接、标签、active 导航） */
   --accent:        #0F4C75;
   --accent-light:  #2980B9;
+
+  /* CTA 色（行动型：订阅、联系我等按钮） */
+  --cta:           #B45309;
+  --cta-light:     #D97706;
 
   /* 边框 */
   --border:        #E5E7EB;

--- a/app/services/page.tsx
+++ b/app/services/page.tsx
@@ -125,8 +125,8 @@ export default function ServicesPage() {
             AI 落地咨询
           </h2>
           <p className="text-sm text-[var(--text-secondary)] mb-6 leading-relaxed">
-            基于我在异乡好居的实践——管理 3 万+留学渠道合作伙伴、累计服务 40 万客户、
-            交易 75 亿的业务经验，帮助国际教育机构找到 AI 落地的切入点。
+            基于我在异乡好居推动 AI 落地的真实经验，帮助国际教育机构找到切入点。
+            不讲概念，只做能量化效果的事。
           </p>
 
           <div className="space-y-4">
@@ -172,31 +172,25 @@ export default function ServicesPage() {
               <li className="flex items-start gap-2">
                 <span className="text-[var(--accent)] mt-0.5 shrink-0">—</span>
                 <span>
-                  异乡好居副总裁，负责留学渠道部，维护超过 3 万名合作伙伴
+                  不是外部顾问，是在自己业务上跑通 AI 的人——已落地 AI 客服、推荐引擎、数据分析自动化
                 </span>
               </li>
               <li className="flex items-start gap-2">
                 <span className="text-[var(--accent)] mt-0.5 shrink-0">—</span>
                 <span>
-                  异乡缴费负责人，5 年累计服务 18 万客户，交易金额超 75 亿
+                  以非程序员身份用 Vibe Coding 独立构建了两个产品——证明「不会写代码」不是障碍
                 </span>
               </li>
               <li className="flex items-start gap-2">
                 <span className="text-[var(--accent)] mt-0.5 shrink-0">—</span>
                 <span>
-                  用 Vibe Coding 独立构建了异乡人才（AI 驱动的留学生求职平台，10,645 个活跃岗位）
+                  实训方法论经过验证：首期 10 位主管全程参与，培训后工具实际使用率 80%
                 </span>
               </li>
               <li className="flex items-start gap-2">
                 <span className="text-[var(--accent)] mt-0.5 shrink-0">—</span>
                 <span>
-                  完成第一期 AI 实训：10 位主管，4 周 8 节课，每人交付 4 个可用工具
-                </span>
-              </li>
-              <li className="flex items-start gap-2">
-                <span className="text-[var(--accent)] mt-0.5 shrink-0">—</span>
-                <span>
-                  以非程序员身份，用 AI 编写了 18,000+ 行代码和 505 个测试用例
+                  沉淀了 Gate-Review 评审方法论 + Vibe Coding 开发方法，可直接复用
                 </span>
               </li>
             </ul>

--- a/components/layout/Header.tsx
+++ b/components/layout/Header.tsx
@@ -52,7 +52,7 @@ export function Header() {
             ))}
             <a
               href="mailto:ceo@dingning.ai"
-              className="inline-flex items-center gap-1.5 text-sm font-medium text-white bg-[var(--accent)] hover:bg-[var(--accent-light)] px-4 py-2 rounded-lg transition-colors duration-200"
+              className="inline-flex items-center gap-1.5 text-sm font-medium text-white bg-[var(--cta)] hover:bg-[var(--cta-light)] px-4 py-2 rounded-lg transition-colors duration-200"
             >
               <Mail size={14} />
               联系我

--- a/components/sections/AboutBrief.tsx
+++ b/components/sections/AboutBrief.tsx
@@ -10,30 +10,20 @@ export function AboutBrief() {
             关于我
           </h2>
           <p className="text-base text-[var(--text-secondary)] leading-relaxed mb-4">
-            我是 Ning Ding，异乡好居副总裁，负责留学渠道部，维护超过
-            <span className="font-medium text-[var(--text-primary)]"> 3 万</span>名合作伙伴。
-            异乡好居累计服务超过
-            <span className="font-medium text-[var(--text-primary)]"> 40 万</span>名客户，
-            覆盖
-            <span className="font-medium text-[var(--text-primary)]"> 27 个国家和地区</span>。
-            同时负责异乡缴费，5 年累计服务
-            <span className="font-medium text-[var(--text-primary)]"> 18 万</span>客户，
-            交易金额超
-            <span className="font-medium text-[var(--text-primary)]"> 75 亿</span>。
+            我是 Ning Ding，异乡好居副总裁、异乡缴费负责人。
+            在国际教育行业深耕多年，现在正做一件事：
+            帮助这个行业的从业者学会用 AI 提升工作效率——从自己的团队开始。
           </p>
           <p className="text-base text-[var(--text-secondary)] leading-relaxed mb-4">
-            我正在做一件事：让国际教育产业链的从业者学会用 AI 提升工作效率。
-            已经完成了第一期 Vibe Coding 实训——10 位主管，4 周 8 节课，
+            第一期 Vibe Coding 实训已完成——10 位主管，4 周 8 节课，
             佣金分析时间从 30 分钟降到 3 分钟。
-          </p>
-          <p className="text-base text-[var(--text-secondary)] leading-relaxed mb-6">
-            这个网站记录我的实践与思考，也是我向行业布道 AI 的阵地。
+            这个网站记录我的实践与思考。
           </p>
           <Link
             href="/about"
             className="inline-flex items-center gap-1.5 text-sm text-[var(--accent)] hover:text-[var(--accent-light)] transition-colors duration-200"
           >
-            了解更多
+            了解完整经历
             <ArrowRight size={14} />
           </Link>
         </div>

--- a/components/ui/NewsletterForm.tsx
+++ b/components/ui/NewsletterForm.tsx
@@ -62,8 +62,8 @@ export function NewsletterForm() {
         <button
           type="submit"
           disabled={status === "loading"}
-          className="px-4 py-2.5 text-sm font-medium text-white bg-[var(--accent)] rounded-lg
-                     hover:bg-[var(--accent-light)] transition-colors duration-200
+          className="px-4 py-2.5 text-sm font-medium text-white bg-[var(--cta)] rounded-lg
+                     hover:bg-[var(--cta-light)] transition-colors duration-200
                      flex items-center gap-2 disabled:opacity-50"
         >
           {status === "loading" ? (

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -22,6 +22,10 @@ const config: Config = {
           DEFAULT: "var(--accent)",
           light: "var(--accent-light)",
         },
+        cta: {
+          DEFAULT: "var(--cta)",
+          light: "var(--cta-light)",
+        },
         border: {
           DEFAULT: "var(--border)",
           strong: "var(--border-strong)",


### PR DESCRIPTION
## Summary

- **C-01 色彩系统扩展**：新增琥珀色 CTA 专用色（#B45309），订阅按钮和联系我按钮改用 CTA 色，链接/标签/导航保持海军蓝 accent 色，形成「信息型 vs 行动型」双层视觉层次
- **A-03 数字去重**：首页 AboutBrief 去掉具体数字改为定位型文案，服务页去掉重复背景数字改为侧重方法论，关于页保持完整数字作为唯一详情页

新增 9 个测试用例（总计 45 个），build 通过。

## Test plan

- [x] `npm test` — 45 个测试全部通过
- [x] `npm run build` — 32 个页面静态生成成功
- [ ] Vercel Preview 确认 CTA 按钮琥珀色视觉效果
- [ ] 确认首页/服务页/关于页数字不再重复

🤖 Generated with [Claude Code](https://claude.com/claude-code)