### PR TITLE
chore: switch blog generator to Claude Sonnet 4

### DIFF
--- a/scripts/blog_config.yaml
+++ b/scripts/blog_config.yaml
@@ -4,8 +4,8 @@
 # provider: "anthropic" | "deepseek" | "openai"
 # 切换模型只需修改以下三行
 llm:
-  provider: "deepseek"
-  model: "deepseek-chat"
+  provider: "anthropic"
+  model: "claude-sonnet-4-6"
   max_tokens: 4096
   # base_url: "https://api.deepseek.com"  # 可选，默认按 provider 自动设置
   #


### PR DESCRIPTION
## Summary
- 博客自动生成从 DeepSeek 切换到 Claude Sonnet 4
- DeepSeek 近两次定时生成都因编造数据（3万行 vs 实际1.8万行）被一致性检查拦截
- Claude 事实遵从度更好，单次成本约 ¥0.7，月成本约 ¥7

## Test plan
- [ ] CI 通过（code-quality）
- [ ] 合并后手动触发一次 daily-blog workflow 验证 Claude 生成效果

🤖 Generated with [Claude Code](https://claude.com/claude-code)