### PR TITLE
feat(coffee): 接入异乡早咖啡每日要闻路由

### DIFF
--- a/app/coffee/[slug]/page.tsx
+++ b/app/coffee/[slug]/page.tsx
@@ -110,10 +110,10 @@ export default function CoffeeDetailPage({ params }: Props) {
             本页为新闻索引，每条仅含中文标题与简要事实摘要，所有内容版权归原媒体所有。
             如需 takedown，请联系{" "}
             <a
-              href="mailto:hello@dingning.ai"
+              href="mailto:ceo@dingning.ai"
               className="underline hover:text-[var(--accent)]"
             >
-              hello@dingning.ai
+              ceo@dingning.ai
             </a>
             。
           </p>

--- a/app/coffee/[slug]/page.tsx
+++ b/app/coffee/[slug]/page.tsx
@@ -1,0 +1,124 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { notFound } from "next/navigation";
+import { MDXRemote } from "next-mdx-remote/rsc";
+import remarkGfm from "remark-gfm";
+import { ArrowLeft, ArrowRight } from "lucide-react";
+import { getAllCoffee, getCoffeeBySlug, getAdjacentCoffee } from "@/lib/coffee";
+import { mdxComponents } from "@/components/mdx/MdxComponents";
+
+export const revalidate = 3600;
+
+interface Props {
+  params: { slug: string };
+}
+
+export function generateStaticParams() {
+  return getAllCoffee().map((issue) => ({ slug: issue.slug }));
+}
+
+export function generateMetadata({ params }: Props): Metadata {
+  const issue = getCoffeeBySlug(decodeURIComponent(params.slug));
+  if (!issue) return {};
+  return {
+    title: issue.meta.title,
+    description: issue.meta.description,
+    openGraph: {
+      title: issue.meta.title,
+      description: issue.meta.description,
+      type: "article",
+      publishedTime: issue.meta.date,
+      url: `https://dingning.ai/coffee/${params.slug}`,
+    },
+  };
+}
+
+export default function CoffeeDetailPage({ params }: Props) {
+  const slug = decodeURIComponent(params.slug);
+  const issue = getCoffeeBySlug(slug);
+  if (!issue) notFound();
+
+  const { prev, next } = getAdjacentCoffee(slug);
+
+  return (
+    <article className="py-20 md:py-28">
+      <div className="max-w-3xl mx-auto px-4 md:px-6 lg:px-8">
+        <Link
+          href="/coffee"
+          className="inline-flex items-center gap-1.5 text-sm text-[var(--text-muted)] hover:text-[var(--accent)] transition-colors duration-200 mb-8"
+        >
+          <ArrowLeft size={14} />
+          返回早咖啡
+        </Link>
+
+        <header className="mb-12">
+          <h1 className="text-3xl md:text-4xl font-semibold text-[var(--text-primary)] mb-4 leading-tight">
+            {issue.meta.title}
+          </h1>
+          <div className="flex items-center gap-3 text-sm text-[var(--text-muted)]">
+            <time dateTime={issue.meta.date}>{issue.meta.date}</time>
+          </div>
+        </header>
+
+        <div className="prose">
+          <MDXRemote
+            source={issue.content}
+            components={mdxComponents}
+            options={{ mdxOptions: { remarkPlugins: [remarkGfm] } }}
+          />
+        </div>
+
+        <nav className="mt-16 pt-8 border-t border-[var(--border)]">
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+            {prev ? (
+              <Link
+                href={`/coffee/${prev.slug}`}
+                className="group flex flex-col gap-1 p-4 border border-[var(--border)] rounded-xl hover:border-[var(--accent)]/30 hover:shadow-[var(--card-shadow)] transition-all duration-300"
+              >
+                <span className="text-xs text-[var(--text-muted)] flex items-center gap-1">
+                  <ArrowLeft size={12} />
+                  上一期
+                </span>
+                <span className="text-sm font-medium text-[var(--text-primary)] group-hover:text-[var(--accent)] transition-colors duration-200 line-clamp-1">
+                  {prev.title}
+                </span>
+              </Link>
+            ) : (
+              <div />
+            )}
+            {next ? (
+              <Link
+                href={`/coffee/${next.slug}`}
+                className="group flex flex-col gap-1 p-4 border border-[var(--border)] rounded-xl hover:border-[var(--accent)]/30 hover:shadow-[var(--card-shadow)] transition-all duration-300 md:text-right"
+              >
+                <span className="text-xs text-[var(--text-muted)] flex items-center gap-1 md:justify-end">
+                  下一期
+                  <ArrowRight size={12} />
+                </span>
+                <span className="text-sm font-medium text-[var(--text-primary)] group-hover:text-[var(--accent)] transition-colors duration-200 line-clamp-1">
+                  {next.title}
+                </span>
+              </Link>
+            ) : (
+              <div />
+            )}
+          </div>
+        </nav>
+
+        <footer className="mt-12 pt-8 border-t border-[var(--border)]">
+          <p className="text-xs text-[var(--text-muted)] leading-relaxed">
+            本页为新闻索引，每条仅含中文标题与简要事实摘要，所有内容版权归原媒体所有。
+            如需 takedown，请联系{" "}
+            <a
+              href="mailto:hello@dingning.ai"
+              className="underline hover:text-[var(--accent)]"
+            >
+              hello@dingning.ai
+            </a>
+            。
+          </p>
+        </footer>
+      </div>
+    </article>
+  );
+}

--- a/app/coffee/page.tsx
+++ b/app/coffee/page.tsx
@@ -1,0 +1,67 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { getAllCoffee } from "@/lib/coffee";
+
+export const metadata: Metadata = {
+  title: "异乡早咖啡",
+  description: "国际教育每日要闻 · AI 辅助生成 · 每日更新",
+  openGraph: {
+    title: "异乡早咖啡",
+    description: "国际教育每日要闻 · AI 辅助生成 · 每日更新",
+    type: "website",
+    url: "https://dingning.ai/coffee",
+  },
+};
+
+export default function CoffeeIndexPage() {
+  const issues = getAllCoffee();
+
+  return (
+    <section className="py-20 md:py-28">
+      <div className="max-w-3xl mx-auto px-4 md:px-6 lg:px-8">
+        <h1 className="text-3xl md:text-4xl font-semibold text-[var(--text-primary)] mb-4">
+          异乡早咖啡
+        </h1>
+        <p className="text-base text-[var(--text-secondary)] mb-10">
+          国际教育每日要闻 · AI 辅助生成 · 每日早 7:00 推送至社群
+        </p>
+
+        {issues.length === 0 ? (
+          <div className="border border-dashed border-[var(--border)] rounded-xl p-8 text-center">
+            <p className="text-sm text-[var(--text-muted)]">
+              暂无内容，每日早 7:00 自动更新。
+            </p>
+          </div>
+        ) : (
+          <ul className="space-y-3">
+            {issues.map((issue) => (
+              <li key={issue.slug}>
+                <Link
+                  href={`/coffee/${issue.slug}`}
+                  className="block p-4 md:p-5 border border-[var(--border)] rounded-xl hover:border-[var(--accent)]/30 hover:shadow-[var(--card-shadow)] transition-all duration-300"
+                >
+                  <div className="flex items-baseline justify-between gap-4">
+                    <h2 className="text-base md:text-lg font-medium text-[var(--text-primary)]">
+                      {issue.title}
+                    </h2>
+                    <time
+                      dateTime={issue.date}
+                      className="text-xs text-[var(--text-muted)] whitespace-nowrap"
+                    >
+                      {issue.date}
+                    </time>
+                  </div>
+                  {issue.description && (
+                    <p className="text-sm text-[var(--text-secondary)] mt-2 line-clamp-2">
+                      {issue.description}
+                    </p>
+                  )}
+                </Link>
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+    </section>
+  );
+}

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -1,10 +1,12 @@
 import { MetadataRoute } from "next";
 import { getAllPosts } from "@/lib/mdx";
+import { getAllCoffee } from "@/lib/coffee";
 
 const BASE_URL = "https://dingning.ai";
 
 export default function sitemap(): MetadataRoute.Sitemap {
   const posts = getAllPosts();
+  const coffeeIssues = getAllCoffee();
 
   const staticPages: MetadataRoute.Sitemap = [
     {
@@ -15,6 +17,12 @@ export default function sitemap(): MetadataRoute.Sitemap {
     },
     {
       url: `${BASE_URL}/blog`,
+      lastModified: new Date(),
+      changeFrequency: "daily",
+      priority: 0.8,
+    },
+    {
+      url: `${BASE_URL}/coffee`,
       lastModified: new Date(),
       changeFrequency: "daily",
       priority: 0.8,
@@ -52,5 +60,12 @@ export default function sitemap(): MetadataRoute.Sitemap {
     priority: 0.6,
   }));
 
-  return [...staticPages, ...blogPages];
+  const coffeePages: MetadataRoute.Sitemap = coffeeIssues.map((issue) => ({
+    url: `${BASE_URL}/coffee/${issue.slug}`,
+    lastModified: new Date(issue.date),
+    changeFrequency: "monthly",
+    priority: 0.5,
+  }));
+
+  return [...staticPages, ...blogPages, ...coffeePages];
 }

--- a/components/layout/Footer.tsx
+++ b/components/layout/Footer.tsx
@@ -4,6 +4,7 @@ import { WeChatPopover } from "@/components/ui/WeChatPopover";
 
 const siteLinks = [
   { label: "博客", href: "/blog" },
+  { label: "早咖啡", href: "/coffee" },
   { label: "服务", href: "/services" },
   { label: "项目", href: "/projects" },
   { label: "资源", href: "/resources" },

--- a/components/layout/Header.tsx
+++ b/components/layout/Header.tsx
@@ -9,6 +9,7 @@ import { ThemeToggle } from "@/components/ui/ThemeToggle";
 
 const navItems = [
   { label: "博客", href: "/blog" },
+  { label: "早咖啡", href: "/coffee" },
   { label: "服务", href: "/services" },
   { label: "项目", href: "/projects" },
   { label: "资源", href: "/resources" },
@@ -21,6 +22,7 @@ export function Header() {
 
   const isActive = (href: string) => {
     if (href === "/blog") return pathname === "/blog" || pathname.startsWith("/blog/");
+    if (href === "/coffee") return pathname === "/coffee" || pathname.startsWith("/coffee/");
     return pathname === href;
   };
 

--- a/content/coffee/2026-04-27.mdx
+++ b/content/coffee/2026-04-27.mdx
@@ -1,0 +1,31 @@
+---
+title: "异乡早咖啡 · 2026-04-27"
+date: "2026-04-27"
+slug: "2026-04-27"
+description: "国际教育每日要闻 · 5 条精选 · AI 辅助生成"
+published: true
+---
+
+国际教育每日要闻 · AI 辅助生成 · 每日早 7:00 推送至社群
+
+## 今日要闻
+
+### 1. 美国社区大学成升学新路径
+争议并存的低成本学位通道。
+**[原文 →](https://universitybusiness.com/community-college-is-the-new-path-to-a-bachelors-degree-not-everyone-likes-it/)** University Business
+
+### 2. 中国出境留学下滑，市场迈入成熟期
+分析称留学市场进入高端化阶段。
+**[原文 →](https://thepienews.com/chinas-outbound-student-drop-signals-maturing-market/)** The Pie News
+
+### 3. 加速进化机器人亮相中国教育装备展
+具身智能教育方案引发关注。
+**[原文 →](https://www.jiemodui.com/N/139343.html)** 芥末堆
+
+### 4. 密歇根公立大学或遭 60% 州拨款削减
+密歇根州立和密大面临史上最大削减压力。
+**[原文 →](https://www.highereddive.com/news/michigan-state-university-of-michigan-face-over-60-cut-under-state-fundin/818270/)** Higher Ed Dive
+
+### 5. 蒙大拿高校开放原住民学费豁免
+新政策让符合条件的原住民学生免缴学费。
+**[原文 →](https://www.insidehighered.com/news/students/diversity/2026/04/24/montana-universities-open-native-american-tuition-waiver)** Inside Higher Ed

--- a/lib/coffee.ts
+++ b/lib/coffee.ts
@@ -1,0 +1,60 @@
+import fs from "fs";
+import path from "path";
+import matter from "gray-matter";
+
+export interface CoffeeMeta {
+  slug: string;
+  title: string;
+  date: string;
+  description: string;
+  published: boolean;
+}
+
+const CONTENT_DIR = path.join(process.cwd(), "content/coffee");
+
+function readIssues(): Array<{ filename: string; data: matter.GrayMatterFile<string>["data"]; content: string }> {
+  if (!fs.existsSync(CONTENT_DIR)) return [];
+  const files = fs.readdirSync(CONTENT_DIR).filter((f) => f.endsWith(".mdx"));
+  return files.map((filename) => {
+    const filePath = path.join(CONTENT_DIR, filename);
+    const raw = fs.readFileSync(filePath, "utf-8");
+    const { data, content } = matter(raw);
+    return { filename, data, content };
+  });
+}
+
+function toMeta(filename: string, data: matter.GrayMatterFile<string>["data"]): CoffeeMeta {
+  const slug = data.slug || filename.replace(/\.mdx$/, "");
+  return {
+    slug,
+    title: data.title,
+    date: data.date,
+    description: data.description || "",
+    published: data.published !== false,
+  };
+}
+
+export function getAllCoffee(): CoffeeMeta[] {
+  return readIssues()
+    .map(({ filename, data }) => toMeta(filename, data))
+    .filter((m) => m.published)
+    .sort((a, b) => new Date(b.date).getTime() - new Date(a.date).getTime());
+}
+
+export function getCoffeeBySlug(slug: string): { meta: CoffeeMeta; content: string } | null {
+  for (const { filename, data, content } of readIssues()) {
+    const meta = toMeta(filename, data);
+    if (meta.slug === slug) return { meta, content };
+  }
+  return null;
+}
+
+export function getAdjacentCoffee(slug: string): { prev: CoffeeMeta | null; next: CoffeeMeta | null } {
+  const issues = getAllCoffee();
+  const idx = issues.findIndex((i) => i.slug === slug);
+  if (idx === -1) return { prev: null, next: null };
+  return {
+    prev: idx < issues.length - 1 ? issues[idx + 1] : null,
+    next: idx > 0 ? issues[idx - 1] : null,
+  };
+}


### PR DESCRIPTION
## Summary

- 新增 `/coffee` 索引页 + `/coffee/[slug]` 详情页，承载 ai-news-bot 每日推送的国际教育新闻索引
- 主导航 + 页脚 + sitemap 同步加入"早咖啡"入口
- MDX 内容遵循"轻量索引"原则：中文标题 + ≤30 字摘要 + 显眼原文链接 + 底部 takedown 邮箱，规避版权风险

## 跨项目依赖

ai-news-bot 通过 GitHub Contents API 每日提交 `content/coffee/{date}.mdx` → 触发 Vercel 部署 → 群消息附 `dingning.ai/coffee/{date}` 详情入口。

详见 [ai-news-bot/dingning_publisher.py](https://github.com/yalding8/ai-news-bot/blob/main/dingning_publisher.py)（待 push）。

## Test plan

- [x] 本地 npm run build 成功，`/coffee` + `/coffee/2026-04-27` prerender 通过
- [x] 本地 npm run lint 0 警告
- [x] 测试套件失败数与 main 一致（6 个预存失败，与本 PR 无关）
- [ ] Vercel preview 部署成功
- [ ] preview 上 `/coffee` 列表渲染正常
- [ ] preview 上 `/coffee/2026-04-27` 详情渲染正常（含 prev/next + takedown）
- [ ] 主导航 + 页脚显示"早咖啡"，点击跳转正确

🤖 Generated with [Claude Code](https://claude.com/claude-code)