### PR TITLE
feat(security): API 速率限制 + 邮箱校验 (F5)

### DIFF
--- a/__tests__/lib/ratelimit.test.ts
+++ b/__tests__/lib/ratelimit.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect } from "vitest";
+import { clientIp, allow } from "@/lib/ratelimit";
+import { isValidEmail } from "@/lib/validation";
+
+describe("isValidEmail", () => {
+  it("accepts normal addresses", () => {
+    expect(isValidEmail("a@b.com")).toBe(true);
+    expect(isValidEmail("ning.ding@dingning.ai")).toBe(true);
+    expect(isValidEmail("  trimmed@x.io  ")).toBe(true);
+  });
+
+  it("rejects non-strings and empty", () => {
+    expect(isValidEmail(undefined)).toBe(false);
+    expect(isValidEmail(null)).toBe(false);
+    expect(isValidEmail(123)).toBe(false);
+    expect(isValidEmail("")).toBe(false);
+    expect(isValidEmail("   ")).toBe(false);
+  });
+
+  it("rejects malformed addresses", () => {
+    expect(isValidEmail("no-at-sign")).toBe(false);
+    expect(isValidEmail("a@b")).toBe(false);
+    expect(isValidEmail("a @b.com")).toBe(false);
+    expect(isValidEmail("a@@b.com")).toBe(false);
+  });
+
+  it("rejects absurdly long input", () => {
+    expect(isValidEmail("a".repeat(250) + "@b.com")).toBe(false);
+  });
+});
+
+describe("clientIp", () => {
+  const reqWith = (headers: Record<string, string>) =>
+    new Request("https://x.test", { headers });
+
+  it("takes the first x-forwarded-for entry", () => {
+    expect(clientIp(reqWith({ "x-forwarded-for": "1.2.3.4, 5.6.7.8" }))).toBe(
+      "1.2.3.4"
+    );
+  });
+
+  it("falls back to x-real-ip", () => {
+    expect(clientIp(reqWith({ "x-real-ip": "9.9.9.9" }))).toBe("9.9.9.9");
+  });
+
+  it("returns 'anonymous' when no IP headers present", () => {
+    expect(clientIp(reqWith({}))).toBe("anonymous");
+  });
+});
+
+describe("allow (fail-open)", () => {
+  it("allows when limiter is null (Redis not configured)", async () => {
+    expect(await allow(null, "any-id")).toBe(true);
+  });
+
+  it("delegates to the limiter when present", async () => {
+    const fakeAllow = { limit: async () => ({ success: true }) } as never;
+    const fakeDeny = { limit: async () => ({ success: false }) } as never;
+    expect(await allow(fakeAllow, "id")).toBe(true);
+    expect(await allow(fakeDeny, "id")).toBe(false);
+  });
+});

--- a/app/api/newsletter/route.ts
+++ b/app/api/newsletter/route.ts
@@ -1,17 +1,29 @@
 import { NextRequest, NextResponse } from "next/server";
+import { allow, clientIp, getNewsletterLimiter } from "@/lib/ratelimit";
+import { isValidEmail } from "@/lib/validation";
 
 export async function POST(req: NextRequest) {
+  // 速率限制（按 IP）——防止脚本刷爆 Buttondown 配额 / 垃圾订阅。
+  // Redis 未配置时 fail-open（个人站，可用性优先）。
+  if (!(await allow(getNewsletterLimiter(), clientIp(req)))) {
+    return NextResponse.json(
+      { error: "订阅过于频繁，请稍后再试。" },
+      { status: 429 }
+    );
+  }
+
   const { email } = await req.json();
 
-  if (!email || typeof email !== "string") {
-    return NextResponse.json({ error: "Email is required" }, { status: 400 });
+  // 后端不信任前端校验：强制格式 + 长度，再转发第三方。
+  if (!isValidEmail(email)) {
+    return NextResponse.json({ error: "请输入有效的邮箱地址" }, { status: 400 });
   }
 
   const apiKey = process.env.BUTTONDOWN_API_KEY;
 
   if (!apiKey) {
-    // Buttondown 未配置时，仅记录并返回成功（开发阶段）
-    console.log(`[Newsletter] Subscription request: ${email} (Buttondown not configured)`);
+    // Buttondown 未配置时，仅记录并返回成功（开发阶段）。不打印邮箱（隐私）。
+    console.log("[Newsletter] Subscription request received (Buttondown not configured)");
     return NextResponse.json({ success: true });
   }
 

--- a/app/api/views/[slug]/route.ts
+++ b/app/api/views/[slug]/route.ts
@@ -1,15 +1,22 @@
 import { NextRequest, NextResponse } from "next/server";
 import { incrementViews, getViews } from "@/lib/views";
+import { allow, clientIp, getViewsLimiter } from "@/lib/ratelimit";
 
 export async function POST(
-  _req: NextRequest,
+  req: NextRequest,
   { params }: { params: { slug: string } }
 ) {
   const { slug } = params;
 
   if (!process.env.UPSTASH_REDIS_REST_URL) {
-    console.log(`[Views] Increment request: ${slug} (Upstash not configured)`);
+    console.log("[Views] Increment request (Upstash not configured)");
     return NextResponse.json({ count: 0 });
+  }
+
+  // 速率限制（按 IP + slug）——防止脚本无限 INCR 刷假浏览量 / 耗 Redis 配额。
+  // 超限时不再自增，返回当前真实计数。
+  if (!(await allow(getViewsLimiter(), `${clientIp(req)}:${slug}`))) {
+    return NextResponse.json({ count: await getViews(slug) }, { status: 429 });
   }
 
   const count = await incrementViews(slug);

--- a/lib/ratelimit.ts
+++ b/lib/ratelimit.ts
@@ -1,0 +1,75 @@
+import { Ratelimit } from "@upstash/ratelimit";
+import { Redis } from "@upstash/redis";
+
+/**
+ * Shared rate limiting backed by Upstash Redis.
+ *
+ * Design: fail-open. When Upstash isn't configured (or unreachable), requests
+ * are allowed rather than rejected — this is a personal site, and a Redis
+ * outage must not take down newsletter signups or page views. The limiter
+ * activates automatically once UPSTASH_REDIS_REST_URL/TOKEN are present.
+ */
+
+function getRedis(): Redis | null {
+  const url = process.env.UPSTASH_REDIS_REST_URL;
+  const token = process.env.UPSTASH_REDIS_REST_TOKEN;
+  if (!url || !token) return null;
+  return new Redis({ url, token });
+}
+
+// `undefined` = not yet initialized; `null` = Redis not configured (fail-open).
+let newsletterLimiter: Ratelimit | null | undefined;
+let viewsLimiter: Ratelimit | null | undefined;
+
+export function getNewsletterLimiter(): Ratelimit | null {
+  if (newsletterLimiter === undefined) {
+    const redis = getRedis();
+    newsletterLimiter = redis
+      ? new Ratelimit({
+          redis,
+          limiter: Ratelimit.slidingWindow(5, "1 h"),
+          prefix: "rl:newsletter",
+          analytics: false,
+        })
+      : null;
+  }
+  return newsletterLimiter;
+}
+
+export function getViewsLimiter(): Ratelimit | null {
+  if (viewsLimiter === undefined) {
+    const redis = getRedis();
+    viewsLimiter = redis
+      ? new Ratelimit({
+          redis,
+          limiter: Ratelimit.slidingWindow(10, "1 m"),
+          prefix: "rl:views",
+          analytics: false,
+        })
+      : null;
+  }
+  return viewsLimiter;
+}
+
+/** Best-effort client IP from proxy headers (Vercel sets x-forwarded-for). */
+export function clientIp(req: Request): string {
+  const xff = req.headers.get("x-forwarded-for");
+  if (xff) {
+    const first = xff.split(",")[0].trim();
+    if (first) return first;
+  }
+  return req.headers.get("x-real-ip")?.trim() || "anonymous";
+}
+
+/**
+ * Returns true if the request is allowed. Fail-open: a null limiter (Redis not
+ * configured) always allows.
+ */
+export async function allow(
+  limiter: Ratelimit | null,
+  identifier: string
+): Promise<boolean> {
+  if (!limiter) return true;
+  const { success } = await limiter.limit(identifier);
+  return success;
+}

--- a/lib/validation.ts
+++ b/lib/validation.ts
@@ -1,0 +1,14 @@
+/**
+ * Email validation for API inputs. The frontend uses HTML5 type="email",
+ * but the backend must not trust that — validate format and bound length
+ * before forwarding to third-party services (Buttondown).
+ */
+const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+export function isValidEmail(value: unknown): value is string {
+  if (typeof value !== "string") return false;
+  const email = value.trim();
+  // RFC 5321 caps the full address at 254 chars; reject absurd inputs early.
+  if (email.length === 0 || email.length > 254) return false;
+  return EMAIL_RE.test(email);
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@next/mdx": "^16.1.6",
+        "@upstash/ratelimit": "^2.0.8",
         "@upstash/redis": "^1.37.0",
         "@vercel/analytics": "^2.0.1",
         "clsx": "^2.1.1",
@@ -1975,6 +1976,30 @@
       "os": [
         "win32"
       ]
+    },
+    "node_modules/@upstash/core-analytics": {
+      "version": "0.0.10",
+      "resolved": "https://registry.npmmirror.com/@upstash/core-analytics/-/core-analytics-0.0.10.tgz",
+      "integrity": "sha512-7qJHGxpQgQr9/vmeS1PktEwvNAF7TI4iJDi8Pu2CFZ9YUGHZH4fOP5TfYlZ4aVxfopnELiE4BS4FBjyK7V1/xQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@upstash/redis": "^1.28.3"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@upstash/ratelimit": {
+      "version": "2.0.8",
+      "resolved": "https://registry.npmmirror.com/@upstash/ratelimit/-/ratelimit-2.0.8.tgz",
+      "integrity": "sha512-YSTMBJ1YIxsoPkUMX/P4DDks/xV5YYCswWMamU8ZIfK9ly6ppjRnVOyBhMDXBmzjODm4UQKcxsJPvaeFAijp5w==",
+      "license": "MIT",
+      "dependencies": {
+        "@upstash/core-analytics": "^0.0.10"
+      },
+      "peerDependencies": {
+        "@upstash/redis": "^1.34.3"
+      }
     },
     "node_modules/@upstash/redis": {
       "version": "1.37.0",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   },
   "dependencies": {
     "@next/mdx": "^16.1.6",
+    "@upstash/ratelimit": "^2.0.8",
     "@upstash/redis": "^1.37.0",
     "@vercel/analytics": "^2.0.1",
     "clsx": "^2.1.1",


### PR DESCRIPTION
## 背景（审计 F5）

两个 POST 路由无任何滥用防护：
- `POST /api/newsletter`：可被脚本刷爆 Buttondown 配额 / 制造垃圾订阅。
- `POST /api/views/[slug]`：可被循环 INCR 刷假浏览量 / 耗 Upstash 配额。

## 改动

- **`lib/ratelimit.ts`**：Upstash 滑动窗口限流，**Redis 未配置时 fail-open**（个人站，可用性优先于严格性，Redis 挂了不能连带 500 掉订阅/浏览）。
  - Newsletter：**5 次/小时 per IP**
  - Views：**10 次/分钟 per IP+slug**，超限返回**当前真实计数**且不自增（429）
- **`lib/validation.ts` `isValidEmail()`**：后端不再信任前端 `type=email`，强制格式 + 254 字符上限再转发 Buttondown。
- 两处 `console.log` **脱敏**（不再打印邮箱 / slug）。
- 新增测试：`isValidEmail`、`clientIp`、`allow()` fail-open 路径（9 条）。

## 验证

- `vitest run`：**72/72 全绿**（含新增 9 条）。
- `tsc --noEmit` / `next lint` / `next build`：全部通过。
- 新增依赖：`@upstash/ratelimit`。

## 部署须知

限流仅在 `UPSTASH_REDIS_REST_URL` + `UPSTASH_REDIS_REST_TOKEN` 配置时激活（与现有 views 计数共用同一 Redis，键前缀 `rl:`）。未配置则 fail-open，行为同现状。

🤖 Generated with [Claude Code](https://claude.com/claude-code)