### PR TITLE
feat(provenance): 自动博客产物盖戳（溯源契约 ①）

### DIFF
--- a/scripts/generate_blog_post.py
+++ b/scripts/generate_blog_post.py
@@ -24,6 +24,13 @@ import datetime as dt
 from datetime import datetime
 from pathlib import Path
 
+# 溯源盖戳（溯源契约 ①）。兼容两种导入：直接 `python scripts/x.py`（scripts/ 在
+# sys.path）与作为包 `import scripts.generate_blog_post`（测试）。
+try:
+    from provenance import build_provenance
+except ImportError:
+    from scripts.provenance import build_provenance
+
 # 项目根目录
 ROOT_DIR = Path(__file__).resolve().parent.parent
 CONFIG_PATH = ROOT_DIR / "scripts" / "blog_config.yaml"
@@ -575,6 +582,15 @@ def create_mdx_file(topic: dict, content: str, output_dir: str) -> str:
     if first_para:
         excerpt = first_para
 
+    # 溯源戳（溯源契约 ①）：放进 frontmatter 隐藏字段，不渲染给读者，但 git 可追。
+    # 任何自动生成的文章都能还原出身（repo/script/commit/run/触发方式）。
+    trigger = "github-actions" if os.environ.get("GITHUB_ACTIONS") else "manual"
+    stamp = build_provenance(
+        script="scripts/generate_blog_post.py",
+        repo="dingning-ai",
+        trigger=trigger,
+    )
+
     mdx_content = f"""---
 title: "{topic['title']}"
 date: "{today}"
@@ -583,6 +599,7 @@ excerpt: "{excerpt}"
 tags: {tags_str}
 published: true
 featured: false
+generated_by: "{stamp}"
 ---
 
 {content}

--- a/scripts/provenance.py
+++ b/scripts/provenance.py
@@ -1,0 +1,86 @@
+"""provenance.python.example.py — 跨项目「产物出生证」通用参考实现 (Python)
+
+与 provenance.nodejs.example.ts 等价的 Python 端口。目的、用法、不变量见 TS 版头注释。
+
+怎么用（每个 Python repo 照抄）：
+    1. 拷到你的包里，去掉 `.example`。
+    2. 产物出口处调用：
+           from provenance import build_provenance
+           stamp = build_provenance(script="pipelines/payrent_sku_tasks.py",
+                                    repo="uhomes-data-platform", trigger="cron")
+       把 stamp 放进产物低调位置（文本末行 / 海报页脚 / bitable 隐藏字段），
+       渲染样式是各仓 UI 细节，不写进模板。
+
+设计不变量（复刻时别破坏）：
+    - 零漂移：commit 由运行时 git / CI 环境变量算出。
+    - 绝不崩业务：任何 git 调用失败降级成 'unknown'，不抛异常。
+    - 脏工作区标记：本地未提交跑会标 +dirty。
+    - 可测试：commit / dirty / now 可注入，默认走真实 git / 时钟。
+
+时间一律按 Asia/Shanghai (UTC+8，无夏令时) 输出。
+"""
+from __future__ import annotations
+
+import os
+import subprocess
+from datetime import datetime, timedelta, timezone
+from typing import Callable, Optional
+
+_CST = timezone(timedelta(hours=8))
+
+
+def build_provenance(
+    script: str,
+    repo: str,
+    trigger: Optional[str] = None,
+    *,
+    resolve_commit: Optional[Callable[[], str]] = None,
+    resolve_dirty: Optional[Callable[[], bool]] = None,
+    now: Optional[Callable[[], datetime]] = None,
+) -> str:
+    """构造一行 provenance 文本，例如：
+    '源 uhomes-data-platform/pipelines/payrent.py · 36404c2 · 2026-06-09 14:35 CST · cron'
+    """
+    commit = (resolve_commit or _default_resolve_commit)()
+    dirty = (resolve_dirty or _default_resolve_dirty)()
+    moment = (now or (lambda: datetime.now(_CST)))()
+
+    parts = [
+        f"源 {repo}/{script}",
+        f"{commit}{'+dirty' if dirty else ''}",
+        f"{moment.astimezone(_CST).strftime('%Y-%m-%d %H:%M')} CST",
+    ]
+    if trigger and trigger.strip():
+        parts.append(trigger.strip())
+    return " · ".join(parts)
+
+
+# ------------------------------- 默认实现 -------------------------------
+
+def _default_resolve_commit() -> str:
+    # CI 注入的 SHA 优先（GitHub Actions: GITHUB_SHA；GitLab CI: CI_COMMIT_SHA）
+    from_env = os.environ.get("GITHUB_SHA") or os.environ.get("CI_COMMIT_SHA")
+    if from_env and from_env.strip():
+        return from_env.strip()[:7]
+    try:
+        out = subprocess.run(
+            ["git", "rev-parse", "--short", "HEAD"],
+            capture_output=True, text=True, check=True,
+        )
+        return out.stdout.strip() or "unknown"
+    except Exception:
+        return "unknown"
+
+
+def _default_resolve_dirty() -> bool:
+    # CI 是干净 checkout，无需也无法可靠判断脏工作区
+    if os.environ.get("CI") or os.environ.get("GITHUB_ACTIONS"):
+        return False
+    try:
+        out = subprocess.run(
+            ["git", "status", "--porcelain"],
+            capture_output=True, text=True, check=True,
+        )
+        return bool(out.stdout.strip())
+    except Exception:
+        return False

--- a/tests/test_provenance.py
+++ b/tests/test_provenance.py
@@ -1,0 +1,55 @@
+"""溯源盖戳测试（溯源契约 ① 产物盖戳）。
+
+锁住两件事：
+1. build_provenance 的不变量：`源 <repo>/<script>` 永在；git 不可用时 commit
+   降级为 unknown，但不抛异常、不丢 repo/script。
+2. create_mdx_file 生成的文章 frontmatter 必须含 generated_by 戳，让任何
+   自动生成的文章都能还原出身（哪个 repo/script/run）。
+"""
+
+import os
+from datetime import datetime, timezone, timedelta
+from unittest.mock import patch
+
+import scripts.provenance as prov
+
+
+def test_stamp_always_carries_repo_and_script():
+    stamp = prov.build_provenance(
+        script="scripts/generate_blog_post.py",
+        repo="dingning-ai",
+        trigger="github-actions",
+        resolve_commit=lambda: "abc1234",
+        resolve_dirty=lambda: False,
+        now=lambda: datetime(2026, 6, 20, 14, 35, tzinfo=timezone(timedelta(hours=8))),
+    )
+    assert "源 dingning-ai/scripts/generate_blog_post.py" in stamp
+    assert "abc1234" in stamp
+    assert "github-actions" in stamp
+
+
+def test_stamp_degrades_commit_to_unknown_without_git():
+    """git 挂了：commit=unknown，但 repo/script 仍在，且不抛异常。"""
+    stamp = prov.build_provenance(
+        script="scripts/generate_blog_post.py",
+        repo="dingning-ai",
+        resolve_commit=lambda: "unknown",
+        resolve_dirty=lambda: False,
+        now=lambda: datetime(2026, 6, 20, 14, 35, tzinfo=timezone(timedelta(hours=8))),
+    )
+    assert "源 dingning-ai/scripts/generate_blog_post.py" in stamp
+    assert "unknown" in stamp
+
+
+def test_generated_post_carries_provenance_stamp(tmp_path, sample_topic):
+    """生成的 .mdx frontmatter 必须含 generated_by 戳。"""
+    import scripts.generate_blog_post as gen
+
+    content = "This is the first paragraph.\n\n## Section\n\nMore."
+    with patch.object(gen, "ROOT_DIR", tmp_path):
+        (tmp_path / "content" / "blog").mkdir(parents=True)
+        filepath = gen.create_mdx_file(sample_topic, content, "content/blog")
+
+    fc = open(filepath, encoding="utf-8").read()
+    assert "generated_by:" in fc
+    assert "源 dingning-ai/scripts/generate_blog_post.py" in fc


### PR DESCRIPTION
## 背景

daily-blog 生成器是产出**周期性生产物**（已发布博客文章）的 emitter，但其产物**无任何溯源戳**——看一篇 .mdx 无法还原它由哪个 repo/script/commit/run 生成。这违反溯源契约 ① 面（产物盖戳，无上限地板）。

## 改动

- **`scripts/provenance.py`**：照搬 ops-deploy-kit 通用模板。`build_provenance(script, repo, trigger)` 产出 fail-open 戳。
  - **不变量**：`源 <repo>/<script>` 永在；git 不可用时 commit 降级 `unknown`，不抛异常；CI 用 `GITHUB_SHA`。
- **`generate_blog_post.py`**：每篇文章 frontmatter 加**隐藏 `generated_by` 字段**（不渲染给读者，git 可追）。**无需改 workflow**——GHA 自动注入 `GITHUB_SHA`/`GITHUB_ACTIONS`。
- 测试锁住不变量 + 生成文章必带戳。

## 戳样例

- GHA：`源 dingning-ai/scripts/generate_blog_post.py · deadbee · 2026-06-20 14:35 CST · github-actions`
- 本地手动：`源 .../generate_blog_post.py · 20afc40+dirty · ... · manual`

## 契约三面对照

| 面 | 状态 |
|---|---|
| ① 产物盖戳 | ✅ 本 PR |
| ② 触发进 git | ✅ 已满足（daily-blog.yml 在仓）|
| ③ 死人开关 | ⚠️ 判断题——个人博客缺一天≠丢钱/丢数据，healthchecks 20-cap，留给 owner 决定 |

## 验证

- 盖戳测试 3 条全绿；全量 python 测试无新增失败（4 个预存 API-key 失败与本改动无关）。
- `next build` 容忍 `generated_by` 字段：103 页正常生成，路由可达。

🤖 Generated with [Claude Code](https://claude.com/claude-code)