### PR TITLE
fix(coffee): realign scrambled title↔link in 57 historical digests

### DIFF
--- a/content/coffee/2026-04-27.mdx
+++ b/content/coffee/2026-04-27.mdx
@@ -28,4 +28,3 @@ published: true
 
 ### 5. 最新国际学生晴雨表揭示五大关键发现
 参考权威学生体验报告，帮助孩子选择更匹配的留学目的地与院校。
-**[原文 →](https://www.highereddive.com/news/missouri-state-faces-lawsuit-over-bias-response-policy/818343/)** ICEF Monitor – Market intelligence for international student recruitment

--- a/content/coffee/2026-04-28.mdx
+++ b/content/coffee/2026-04-28.mdx
@@ -20,12 +20,11 @@ published: true
 
 ### 3. 南非大学需求远超容量，副校长警告深刻矛盾
 申请热门留学目的地时，需提前了解其高等教育资源紧张程度。
-**[原文 →](https://www.highereddive.com/spons/the-librarys-next-chapter-a-strategic-role-in-solving-higher-educations/817783/)** The PIE News
+**[原文 →](https://thepienews.com/demand-outstrips-capacity-at-south-africas-universities-warns-uj-vice-chancellor/)** The PIE News
 
 ### 4. 调查显示：文科专业成为毕业生最后悔选择的大学专业
 帮助孩子选择专业时，应平衡兴趣与就业市场长期趋势。
-**[原文 →](https://thepienews.com/demand-outstrips-capacity-at-south-africas-universities-warns-uj-vice-chancellor/)** University Business
+**[原文 →](https://universitybusiness.com/here-are-the-college-majors-that-new-grads-regret-the-most-according-to-a-recent-survey/)** University Business
 
 ### 5. 德国学术交流中心将印度战略重点转向长期合作与研究
 关注主要留学目的国政策变化，把握新兴合作领域与奖学金机会。
-**[原文 →](https://universitybusiness.com/here-are-the-college-majors-that-new-grads-regret-the-most-according-to-a-recent-survey/)** The PIE News

--- a/content/coffee/2026-04-29.mdx
+++ b/content/coffee/2026-04-29.mdx
@@ -12,20 +12,18 @@ published: true
 
 ### 1. 美教育部长预算听证会透露3大关键信号
 申请美本家庭需密切关注教育部改革对助学金和校园民权保护的影响
-**[原文 →](https://monitor.icef.com/2026/04/icef-podcast-sustainable-international-student-recruitment-from-a-uk-china-perspective/)** Higher Ed Dive
 
 ### 2. 德国DAAD调整印度战略：从学生流动转向深度合作
 计划留德的学生可关注更多联合研究机会，但需注意合作项目申请竞争可能加剧
-**[原文 →](https://www.insidehighered.com/news/institutions/community-colleges/2026/04/28/california-ccs-launch-private-university-transfer)** The PIE News
 
 ### 3. AI是否正在重塑应届大学毕业生就业市场？
 留学生选专业应注重培养AI素养，但不必恐慌，复合型人才依然抢手
-**[原文 →](https://universitybusiness.com/here-are-the-college-majors-that-new-grads-regret-the-most-according-to-a-recent-survey/)** University Business
+**[原文 →](https://universitybusiness.com/is-ai-changing-the-job-market-for-new-college-grads/)** University Business
 
 ### 4. 最新调查：这些专业毕业生最后悔，文科居首
 选专业时需兼顾兴趣与就业前景，可考虑辅修量化或技术类课程增强竞争力
-**[原文 →](https://universitybusiness.com/is-ai-changing-the-job-market-for-new-college-grads/)** University Business
+**[原文 →](https://universitybusiness.com/here-are-the-college-majors-that-new-grads-regret-the-most-according-to-a-recent-survey/)** University Business
 
 ### 5. ICEF播客：从英中视角看国际招生可持续性
 赴英留学家庭需更理性评估留学成本与长期回报，重点关注院校就业支持服务
-**[原文 →](https://universitybusiness.com/ask-these-3-questions-about-your-learning-space-technology-budget/)** ICEF Monitor
+**[原文 →](https://monitor.icef.com/2026/04/icef-podcast-sustainable-international-student-recruitment-from-a-uk-china-perspective/)** ICEF Monitor

--- a/content/coffee/2026-04-30.mdx
+++ b/content/coffee/2026-04-30.mdx
@@ -12,20 +12,19 @@ published: true
 
 ### 1. 英国7成大学国际研究生入学人数下滑，签证拒签成主因
 申请英国研究生需提前核查签证材料，关注院校录取与签证联动风险
-**[原文 →](https://thepienews.com/scholarship-targets-study-abroad-gap-for-us-community-colleges/)** ICEF Monitor
+**[原文 →](https://monitor.icef.com/2026/04/uk-7-in-10-universities-report-declining-international-postgraduate-enrolments-visa-rejections-are-part-of-the-story/)** ICEF Monitor
 
 ### 2. 大学生追捧“未来保障”专业，STEM热度被超越
 选专业时兼顾兴趣与抗周期能力，避免盲目追逐短期热门领域
-**[原文 →](https://monitor.icef.com/2026/04/uk-7-in-10-universities-report-declining-international-postgraduate-enrolments-visa-rejections-are-part-of-the-story/)** ICEF Monitor
+**[原文 →](https://monitor.icef.com/2026/04/demand-for-future-proofing-programmes-rising-fast-among-college-aged-students/)** ICEF Monitor
 
 ### 3. 最新数据：多少国际学生在澳大利亚学习？
 澳洲留学热度回升，家长需关注签证配额与工作签证政策变动
-**[原文 →](https://monitor.icef.com/2026/04/demand-for-future-proofing-programmes-rising-fast-among-college-aged-students/)** The PIE News
+**[原文 →](https://thepienews.com/how-many-international-students-are-studying-in-australia-2/)** The PIE News
 
 ### 4. 美教育部长预算听证会透露3大关键信号
 美国教育政策波动期，留学家庭应跟踪联邦资助与签证政策联动
-**[原文 →](https://monitor.icef.com/2026/04/icef-podcast-sustainable-international-student-recruitment-from-a-uk-china-perspective/)** Higher Ed Dive
 
 ### 5. 新奖学金瞄准美国社区大学留学空白
 社区大学学生可借此降低留学成本，家长应主动查询院校合作项目
-**[原文 →](https://thepienews.com/how-many-international-students-are-studying-in-australia-2/)** The PIE News
+**[原文 →](https://thepienews.com/scholarship-targets-study-abroad-gap-for-us-community-colleges/)** The PIE News

--- a/content/coffee/2026-05-01.mdx
+++ b/content/coffee/2026-05-01.mdx
@@ -12,20 +12,18 @@ published: true
 
 ### 1. 美国拟取消身份有效期，留学生签证恐陷混乱
 计划赴美家庭需密切关注签证政策变动，提前规划学业与身份衔接。
-**[原文 →](https://thepienews.com/uk-lords-press-ministers-over-sector-visa-challenges/)** The PIE News
+**[原文 →](https://thepienews.com/replacing-duration-of-status-set-to-cause-chaos/)** The PIE News
 
 ### 2. 英国上议院就签证拒签率向政府施压
 申请英国留学的家庭应重视签证材料合规性，规避拒签风险。
-**[原文 →](https://thepienews.com/replacing-duration-of-status-set-to-cause-chaos/)** The PIE News
+**[原文 →](https://thepienews.com/uk-lords-press-ministers-over-sector-visa-challenges/)** The PIE News
 
 ### 3. 南俄勒冈大学面临关闭风险，需大幅削减开支
 择校时需关注院校财务健康度，避免因学校危机影响学业。
-**[原文 →](https://36kr.com/newsflashes/3789318542072835?f=rss)** Higher Ed Dive
+**[原文 →](https://www.highereddive.com/news/southern-oregon-university-risks-closure-without-deep-cuts-consultants-say/818880/)** Higher Ed Dive
 
 ### 4. 联邦学生贷款新裁决限制借款额度
 计划赴美读研的家庭需重新评估资金方案，应对贷款额度变化。
-**[原文 →](https://36kr.com/newsflashes/3789296202357761?f=rss)** University Business
 
 ### 5. 大学体育领导力变革：CEO模式兴起
 关注大学体育管理创新，有助于理解校园资源分配与体育特长生机会。
-**[原文 →](https://www.highereddive.com/news/southern-oregon-university-risks-closure-without-deep-cuts-consultants-say/818880/)** University Business

--- a/content/coffee/2026-05-02.mdx
+++ b/content/coffee/2026-05-02.mdx
@@ -12,15 +12,13 @@ published: true
 
 ### 1. 近半南亚学生澳洲学签遭拒，印度尼泊尔最甚
 申请澳洲签证需关注生源国差异，南亚学生应提前准备更充分材料。
-**[原文 →](https://universitybusiness.com/which-college-should-they-choose-read-their-stories-then-take-our-quiz/)** The PIE News
+**[原文 →](https://thepienews.com/nearly-half-of-south-asian-applicants-refused-australian-study-visas/)** The PIE News
 
 ### 2. 67%美国高中毕业生因生活成本放弃上大学
 留学家庭需综合评估目的国生活成本，提前规划财务安全垫。
-**[原文 →](https://thepienews.com/nearly-half-of-south-asian-applicants-refused-australian-study-visas/)** Higher Ed Dive
 
 ### 3. 美司法部起诉新泽西州，挑战亲移民大学学费法
 在美留学生需关注各州学费政策变动，无证学生风险加大。
-**[原文 →](https://thepienews.com/europe-looks-beyond-the-region-in-global-student-recruitment-push/)** University Business
 
 ### 4. 国际学生转向未来保障专业，STEM之外需求上升
 选专业时兼顾兴趣与就业韧性，关注跨学科技能培养。
@@ -28,4 +26,4 @@ published: true
 
 ### 5. 欧洲国家放眼域外，全球国际学生招生战略升级
 留学欧洲机会增多，可关注非传统留学国家的新兴项目。
-**[原文 →](https://monitor.icef.com/2026/04/icef-podcast-sustainable-international-student-recruitment-from-a-uk-china-perspective/)** The PIE News
+**[原文 →](https://thepienews.com/europe-looks-beyond-the-region-in-global-student-recruitment-push/)** The PIE News

--- a/content/coffee/2026-05-03.mdx
+++ b/content/coffee/2026-05-03.mdx
@@ -12,11 +12,11 @@ published: true
 
 ### 1. 伊朗战争如何冲击国际学生流动？ICEF最新分析
 中东局势动荡，计划赴该地区留学的家庭需密切关注安全预警与替代方案。
-**[原文 →](https://www.highereddive.com/news/southern-oregon-university-risks-closure-without-deep-cuts-consultants-say/818880/)** ICEF Monitor
+**[原文 →](https://monitor.icef.com/2026/04/how-will-the-war-in-iran-impact-international-student-mobility/)** ICEF Monitor
 
 ### 2. 南俄勒冈大学面临关闭风险，亟需大幅削减预算
 择校时家长应关注院校财务健康度，避免因突发关闭影响学业规划。
-**[原文 →](https://monitor.icef.com/2026/04/how-will-the-war-in-iran-impact-international-student-mobility/)** Higher Ed Dive
+**[原文 →](https://www.highereddive.com/news/southern-oregon-university-risks-closure-without-deep-cuts-consultants-say/818880/)** Higher Ed Dive
 
 ### 3. 从做中学：高校AI教学新范式
 留学生选专业可优先考虑提供AI实践项目的院校，提升未来职场竞争力。
@@ -24,8 +24,8 @@ published: true
 
 ### 4. 英国教育部如何设计大学转型与重组计划
 计划赴英留学家庭需留意院校重组动态，可能影响专业设置与学位认证。
-**[原文 →](https://wonkhe.com/blogs/higher-education-postcard-may-day/)** Wonkhe
+**[原文 →](https://wonkhe.com/blogs/how-dfe-could-design-a-university-transformation-and-restructuring-programme/)** Wonkhe
 
 ### 5. 高等教育明信片：五一劳动节特辑
 节日文化内容可作课余拓展，家长无需过度解读，关注核心学业信息即可。
-**[原文 →](https://wonkhe.com/blogs/how-dfe-could-design-a-university-transformation-and-restructuring-programme/)** Wonkhe
+**[原文 →](https://wonkhe.com/blogs/higher-education-postcard-may-day/)** Wonkhe

--- a/content/coffee/2026-05-04.mdx
+++ b/content/coffee/2026-05-04.mdx
@@ -12,11 +12,10 @@ published: true
 
 ### 1. 澳洲学签拒签率飙升，近半南亚申请人遭拒
 申请澳洲留学需提前准备资金和材料，避开高风险地区拒签潮。
-**[原文 →](https://universitybusiness.com/which-college-should-they-choose-read-their-stories-then-take-our-quiz/)** The PIE News
+**[原文 →](https://thepienews.com/nearly-half-of-south-asian-applicants-refused-australian-study-visas/)** The PIE News
 
 ### 2. 67%美高中毕业生因生活成本放弃读大学
 留学家庭需将目的地生活成本纳入选校核心考量，提前规划预算。
-**[原文 →](https://thepienews.com/nearly-half-of-south-asian-applicants-refused-australian-study-visas/)** Higher Ed Dive
 
 ### 3. 欧洲多国突破区域限制，全球争抢国际生源
 欧洲留学选择增多，可关注非传统留学国家的新奖学金与工签政策。
@@ -28,4 +27,3 @@ published: true
 
 ### 5. 匹兹堡大学分校将为部分学生免学费
 关注美国公立大学分校的学费减免机会，可大幅降低留学成本。
-**[原文 →](https://36kr.com/newsflashes/3793127649500168?f=rss)** Inside Higher Ed

--- a/content/coffee/2026-05-05.mdx
+++ b/content/coffee/2026-05-05.mdx
@@ -12,7 +12,7 @@ published: true
 
 ### 1. 伊朗战争如何影响国际学生流动
 关注中东局势对留学目的国选择的影响，申请时可多国联申分散风险
-**[原文 →](https://www.highereddive.com/news/week-in-review-financial-stress-at-saint-augustines-southern-oregon-univ/819117/)** ICEF Monitor
+**[原文 →](https://monitor.icef.com/2026/04/how-will-the-war-in-iran-impact-international-student-mobility/)** ICEF Monitor
 
 ### 2. 英国上议院就签证难题向部长施压
 英国签证政策趋严，申请英国的学生需提前准备资金和材料以应对审查
@@ -20,12 +20,11 @@ published: true
 
 ### 3. 美国多所大学面临财务压力，项目遭削减
 择校时需关注院校财务健康度，避免因学校财政危机影响学业
-**[原文 →](https://universitybusiness.com/new-college-graduates-overestimate-starting-salaries-by-nearly-24000-report-finds/)** Higher Ed Dive
+**[原文 →](https://www.highereddive.com/news/week-in-review-financial-stress-at-saint-augustines-southern-oregon-univ/819117/)** Higher Ed Dive
 
 ### 4. 报告显示新毕业生高估起薪近2.4万美元
 家长应与孩子理性沟通薪资预期，结合专业与就业市场做好规划
-**[原文 →](https://www.highereddive.com/news/university-of-michigan-virginia-tech-among-colleges-seeking-new-leaders/819125/)** University Business
+**[原文 →](https://universitybusiness.com/new-college-graduates-overestimate-starting-salaries-by-nearly-24000-report-finds/)** University Business
 
 ### 5. 史密斯学院因录取跨性别女性面临联邦调查
 关注美国校园性别政策变化，可能影响校园文化与学生体验
-**[原文 →](https://monitor.icef.com/2026/04/how-will-the-war-in-iran-impact-international-student-mobility/)** Inside Higher Ed

--- a/content/coffee/2026-05-06.mdx
+++ b/content/coffee/2026-05-06.mdx
@@ -16,7 +16,6 @@ published: true
 
 ### 2. 芬兰拟收紧国际学生居留许可财务规则
 计划留学芬兰的家庭需确保充足资金，避免依赖社会福利。
-**[原文 →](https://monitor.icef.com/2026/04/demand-for-future-proofing-programmes-rising-fast-among-college-aged-students/)** The PIE News
 
 ### 3. 韦伯斯特大学因签证资金问题取消国际象棋项目
 特长项目可能受签证政策影响，体育特长生需关注院校稳定性。
@@ -24,8 +23,7 @@ published: true
 
 ### 4. 大学生对“未来防护”课程需求快速上升
 选专业时考虑未来就业韧性，结合兴趣与市场需求。
-**[原文 →](https://thepienews.com/beechside-views-are-we-brave-enough-to-admit-that-one-size-doesnt-fit-all-in-higher-education/)** ICEF Monitor
+**[原文 →](https://monitor.icef.com/2026/04/demand-for-future-proofing-programmes-rising-fast-among-college-aged-students/)** ICEF Monitor
 
 ### 5. 圣地亚哥社区学院系统遭网络攻击致服务中断
 留学生需备份重要资料，关注学校网络安全通知。
-**[原文 →](https://monitor.icef.com/2026/04/icef-podcast-sustainable-international-student-recruitment-from-a-uk-china-perspective/)** University Business

--- a/content/coffee/2026-05-07.mdx
+++ b/content/coffee/2026-05-07.mdx
@@ -16,15 +16,14 @@ published: true
 
 ### 2. 伊朗战争如何影响国际学生流动？ICEF分析三大冲击
 留学目的地选择需考虑地缘政治风险，关注替代国家申请窗口。
-**[原文 →](https://www.insidehighered.com/news/quick-takes/2026/05/06/doj-continues-fight-minnesota-over-state-tuition)** ICEF Monitor
 
 ### 3. 美司法部继续挑战明尼苏达州非公民州内学费政策
 在美无身份学生家庭需留意州内学费政策法律变动，提前规划财务。
-**[原文 →](https://www.insidehighered.com/news/government/politics-elections/2026/05/06/ucla-med-school-accused-racial-discrimination)** Inside Higher Ed
+**[原文 →](https://www.insidehighered.com/news/quick-takes/2026/05/06/doj-continues-fight-minnesota-over-state-tuition)** Inside Higher Ed
 
 ### 4. 美司法部指控UCLA医学院招生种族歧视
 申请美国医学院的学生应关注平权政策变化，多元化背景仍为重要考量。
-**[原文 →](https://universitybusiness.com/new-college-graduates-overestimate-starting-salaries-by-nearly-24000-report-finds/)** Inside Higher Ed
+**[原文 →](https://www.insidehighered.com/news/government/politics-elections/2026/05/06/ucla-med-school-accused-racial-discrimination)** Inside Higher Ed
 
 ### 5. 尼泊尔高校联手力争三年内国际生破万
 南亚留学新选项浮现，可关注尼泊尔特色专业与低成本优势。

--- a/content/coffee/2026-05-08.mdx
+++ b/content/coffee/2026-05-08.mdx
@@ -20,12 +20,9 @@ published: true
 
 ### 3. 芬兰拟收紧国际学生财务规定，领取社会援助或失居留许可
 计划留学芬兰的学生需确保充足资金证明，避免因社会福利记录影响签证续签。
-**[原文 →](https://wonkhe.com/blogs/higher-education-postcard-the-victoria-university-of-manchester/)** The PIE News
 
 ### 4. 南俄勒冈大学拟裁撤或合并13个学术单位以应对财政危机
 在读或申请该校的学生应关注专业存续状态，及时调整选校与转学策略。
-**[原文 →](https://universitybusiness.com/over-200-san-francisco-students-awarded-15k-college-scholarships/)** Higher Ed Dive
 
 ### 5. 雇主预计今年新大学毕业生招聘量将增加5.6%
 2026届毕业生可适度乐观，但需强化人际协作等AI难以替代的能力以提升竞争力。
-**[原文 →](https://thepienews.com/out-galloping-the-four-horsemen-of-higher-education/)** University Business

--- a/content/coffee/2026-05-09.mdx
+++ b/content/coffee/2026-05-09.mdx
@@ -20,12 +20,9 @@ published: true
 
 ### 3. 马耳他非欧盟学生支撑英语教学周数稳定
 非欧盟家庭可关注马耳他英语课程，入学竞争相对缓和且需求稳定。
-**[原文 →](https://wonkhe.com/blogs/looking-after-researchers-themselves-is-a-blind-spot-in-university-research-ethics/)** ICEF Monitor – Market intelligence for international student recruitment
 
 ### 4. 调查显示今年英国青年团体旅行压力加剧
 计划赴英游学的家庭应尽早确认行程，预留签证和通关缓冲时间。
-**[原文 →](https://universitybusiness.com/university-of-kentucky-restructuring-leads-to-hundreds-of-employee-layoffs/)** ICEF Monitor – Market intelligence for international student recruitment
 
 ### 5. 支持性高校环境可降低LGBTQ+学生自杀风险
 择校时考察校园多元包容政策，为孩子选择心理安全的学习环境。
-**[原文 →](https://thepienews.com/the-pieoneer-awards-2026-shortlist-revealed/)** Inside Higher Ed

--- a/content/coffee/2026-05-10.mdx
+++ b/content/coffee/2026-05-10.mdx
@@ -16,16 +16,16 @@ published: true
 
 ### 2. 南俄勒冈大学拟裁撤或合并13个学术单位以应对财政危机
 关注院校财务健康度，择校时需评估专业稳定性，避免因裁撤影响学业连贯性。
-**[原文 →](https://36kr.com/newsflashes/3801708089286151?f=rss)** Higher Ed Dive
+**[原文 →](https://www.highereddive.com/news/southern-oregon-university-plan-would-cut-or-consolidate-13-academic-units/819654/)** Higher Ed Dive
 
 ### 3. 移动凭证成高校运营新承诺，部署即全面公开无试运行期
 家长可提醒学生妥善管理手机权限，防止凭证丢失或被盗用带来安全隐患。
-**[原文 →](https://wonkhe.com/blogs/higher-education-postcard-the-victoria-university-of-manchester/)** University Business
+**[原文 →](https://universitybusiness.com/mobile-credentials-are-an-operational-commitment-evaluate-them-like-one/)** University Business
 
 ### 4. 高等教育明信片：曼彻斯特维多利亚大学的历史回顾
 了解大学历史有助于理解其学术传统，选校时可作为文化匹配度的参考。
-**[原文 →](https://www.highereddive.com/news/southern-oregon-university-plan-would-cut-or-consolidate-13-academic-units/819654/)** Wonkhe
+**[原文 →](https://wonkhe.com/blogs/higher-education-postcard-the-victoria-university-of-manchester/)** Wonkhe
 
 ### 5. 字节跳动申请注册火山词元商标，涉广告销售与网站服务
 科技公司商标布局动态与教育行业无直接关联，可作商业资讯了解。
-**[原文 →](https://universitybusiness.com/mobile-credentials-are-an-operational-commitment-evaluate-them-like-one/)** 36氪
+**[原文 →](https://36kr.com/newsflashes/3801708089286151?f=rss)** 36氪

--- a/content/coffee/2026-05-11.mdx
+++ b/content/coffee/2026-05-11.mdx
@@ -24,8 +24,7 @@ published: true
 
 ### 4. 马耳他非欧盟学生支撑英语教学周数，欧洲生源下滑
 非欧盟生源在马耳他语言留学中占比上升，可关注签证政策与多元文化适应。
-**[原文 →](https://thepienews.com/the-pieoneer-awards-2026-shortlist-revealed/)** ICEF Monitor – Market intelligence for international student recruitment
+**[原文 →](https://monitor.icef.com/2026/05/malta-non-eu-students-keeping-elt-weeks-stable-in-the-face-of-falling-enrolment-from-europe/)** ICEF Monitor – Market intelligence for international student recruitment
 
 ### 5. 支持性校园环境可降低LGBTQ+学生自杀风险
 家长择校时应考察校园包容性政策与心理健康支持，保障孩子安全与归属感。
-**[原文 →](https://monitor.icef.com/2026/05/malta-non-eu-students-keeping-elt-weeks-stable-in-the-face-of-falling-enrolment-from-europe/)** Inside Higher Ed

--- a/content/coffee/2026-05-12.mdx
+++ b/content/coffee/2026-05-12.mdx
@@ -12,20 +12,19 @@ published: true
 
 ### 1. 美国拟取消留学生身份有效期，F/J/I签证学习年限将受限
 留美家庭应尽早规划学业进度，避免签证时限导致学业中断。
-**[原文 →](https://36kr.com/newsflashes/3805592590343688?f=rss)** ICEF Monitor
+**[原文 →](https://monitor.icef.com/2026/05/us-moves-to-end-duration-of-status-for-f-j-and-i-visas-new-rule-could-limit-the-time-international-students-can-study-in-the-us/)** ICEF Monitor
 
 ### 2. 调查：春季美国高校外国本科新生减少20%，签证限制成主因
 申请美国本科需更早准备签证材料，关注政策变动风险。
-**[原文 →](https://thepienews.com/emerging-futures-9-visa-uncertainty-reshapes-student-demand-globally/)** 36氪
+**[原文 →](https://36kr.com/newsflashes/3805592590343688?f=rss)** 36氪
 
 ### 3. 全球调查：签证不确定性正重塑国际学生留学目的地选择
 多国联申可降低签证政策突变带来的风险。
-**[原文 →](https://thepienews.com/canada-overhauls-immigration-consultant-regulations/)** The PIE News
+**[原文 →](https://thepienews.com/emerging-futures-9-visa-uncertainty-reshapes-student-demand-globally/)** The PIE News
 
 ### 4. 穆迪下调哥伦比亚大学评级展望至负面，财务压力引关注
 择校时需关注大学财务健康度，避免因学校财政危机影响学业。
-**[原文 →](https://monitor.icef.com/2026/05/us-moves-to-end-duration-of-status-for-f-j-and-i-visas-new-rule-could-limit-the-time-international-students-can-study-in-the-us/)** Higher Ed Dive
 
 ### 5. 加拿大全面改革移民顾问法规，加大处罚并设立受害者赔偿
 选择加拿大留学移民顾问时，务必核查其合法资质与登记信息。
-**[原文 →](https://www.highereddive.com/news/colorado-state-university-turns-to-layoffs-and-other-cuts-to-manage-budget/819906/)** The PIE News
+**[原文 →](https://thepienews.com/canada-overhauls-immigration-consultant-regulations/)** The PIE News

--- a/content/coffee/2026-05-13.mdx
+++ b/content/coffee/2026-05-13.mdx
@@ -16,7 +16,7 @@ published: true
 
 ### 2. 全球高等教育入学人数达2.69亿，学生流动增三倍
 留学选择更多元，家长可关注新兴留学目的地以降低竞争压力。
-**[原文 →](https://universitybusiness.com/college-admissions-are-confusing-the-right-mix-of-people-and-ai-can-help/)** The PIE News
+**[原文 →](https://thepienews.com/global-he-enrolment-reaches-269-million-as-student-mobility-triples/)** The PIE News
 
 ### 3. 美国创价大学拟收购明德学院国际研究学院
 院校并购可能带来课程资源整合，留学生可关注项目变化。
@@ -24,8 +24,7 @@ published: true
 
 ### 4. 马耳他非欧盟学生支撑英语教学周数，抵消欧洲生源下滑
 小众留学国语言课程性价比高，可作为英语提升的替代选择。
-**[原文 →](https://thepienews.com/global-he-enrolment-reaches-269-million-as-student-mobility-triples/)** ICEF Monitor
+**[原文 →](https://monitor.icef.com/2026/05/malta-non-eu-students-keeping-elt-weeks-stable-in-the-face-of-falling-enrolment-from-europe/)** ICEF Monitor
 
 ### 5. 高校新兴领导者如何培养机构变革能力
 教育管理者应关注变革管理能力，家长可考察学校领导层稳定性。
-**[原文 →](https://monitor.icef.com/2026/05/malta-non-eu-students-keeping-elt-weeks-stable-in-the-face-of-falling-enrolment-from-europe/)** Wonkhe

--- a/content/coffee/2026-05-14.mdx
+++ b/content/coffee/2026-05-14.mdx
@@ -12,20 +12,18 @@ published: true
 
 ### 1. IDP研究：签证不确定性拉低留学投资回报率感知
 申请季家长需关注目标国签证政策变动，提前准备备选方案以降低风险。
-**[原文 →](https://thepienews.com/revealed-the-best-performing-agents-for-new-zealand/)** ICEF Monitor
+**[原文 →](https://monitor.icef.com/2026/05/new-idp-research-shows-link-between-visa-uncertainty-and-the-perceived-roi-of-study-abroad/)** ICEF Monitor
 
 ### 2. 新西兰移民局公布九大生源国最佳留学代理名单
 选择高签证通过率的代理能显著提升获签概率，家长可参考官方数据筛选服务机构。
-**[原文 →](https://monitor.icef.com/2026/05/new-idp-research-shows-link-between-visa-uncertainty-and-the-perceived-roi-of-study-abroad/)** The PIE News
+**[原文 →](https://thepienews.com/revealed-the-best-performing-agents-for-new-zealand/)** The PIE News
 
 ### 3. 传统讲座为何不再适应技能经济时代需求
 家长应关注院校是否提供项目制学习与技能实践，而非仅看排名。
-**[原文 →](https://wonkhe.com/blogs/higher-education-postcard-the-victoria-university-of-manchester/)** The PIE News
 
 ### 4. 肯塔基州立大学学生与校友起诉阻止州法改革
 择校时需留意院校治理稳定性，重大政策变动可能影响学业连贯性。
-**[原文 →](https://www.highereddive.com/news/how-can-colleges-teach-students-to-have-challenging-conversations/820001/)** Higher Ed Dive
 
 ### 5. 高校如何教会学生进行有挑战性的对话
 具备跨文化沟通与批判性思维的孩子更能适应海外课堂，家长可提前引导。
-**[原文 →](https://universitybusiness.com/why-civil-discourse-has-become-timely-for-student-engagement/)** Higher Ed Dive
+**[原文 →](https://www.highereddive.com/news/how-can-colleges-teach-students-to-have-challenging-conversations/820001/)** Higher Ed Dive

--- a/content/coffee/2026-05-15.mdx
+++ b/content/coffee/2026-05-15.mdx
@@ -28,4 +28,3 @@ published: true
 
 ### 5. 高校应追求项目深度而非广度，以提升竞争力
 选校时重点考察目标专业的资源投入与行业联系，而非学校整体规模。
-**[原文 →](https://wonkhe.com/blogs/higher-education-postcard-the-radcliffe-camera/)** Higher Ed Dive

--- a/content/coffee/2026-05-16.mdx
+++ b/content/coffee/2026-05-16.mdx
@@ -20,12 +20,10 @@ published: true
 
 ### 3. 芝加哥大学免学费覆盖家庭收入25万美元以下
 经济条件有限的家庭可关注美国大学免学费政策，合理择校降低负担。
-**[原文 →](https://thepienews.com/koreas-international-students-strapped-with-low-paid-jobs/)** Inside Higher Ed
 
 ### 4. 美教育部长为解散教育部及职能转移辩护
 美国教育部若解散，可能影响联邦学生贷款和国际学生相关服务，需持续关注。
-**[原文 →](https://thepienews.com/mps-and-university-leaders-crowned-winners-of-2026-duolingo-language-challenge/)** University Business
 
 ### 5. 韩国国际学生71%被困低薪食宿岗位
 留学韩国需理性评估打工收入与生活成本，避免陷入低薪困境。
-**[原文 →](https://www.highereddive.com/news/portland-state-university-budget-plan-would-cut-52-jobs/820423/)** The PIE News
+**[原文 →](https://thepienews.com/koreas-international-students-strapped-with-low-paid-jobs/)** The PIE News

--- a/content/coffee/2026-05-17.mdx
+++ b/content/coffee/2026-05-17.mdx
@@ -20,8 +20,8 @@ published: true
 
 ### 3. 高校应追求专业深度而非广度，提升竞争力
 选校时家长应重点考察目标专业的课程纵深与行业衔接，而非学校综合排名
-**[原文 →](https://wonkhe.com/blogs/higher-education-postcard-the-radcliffe-camera/)** Higher Ed Dive
+**[原文 →](https://www.highereddive.com/news/why-colleges-should-embrace-program-depth-over-breadth/819499/)** Higher Ed Dive
 
 ### 4. 高等教育明信片：拉德克利夫圆楼
 了解名校文化地标，有助于学生面试或文书中展现对学校的深度认知
-**[原文 →](https://www.highereddive.com/news/why-colleges-should-embrace-program-depth-over-breadth/819499/)** Wonkhe
+**[原文 →](https://wonkhe.com/blogs/higher-education-postcard-the-radcliffe-camera/)** Wonkhe

--- a/content/coffee/2026-05-18.mdx
+++ b/content/coffee/2026-05-18.mdx
@@ -20,12 +20,11 @@ published: true
 
 ### 3. 韩国71%打工留学生被困低薪餐饮住宿岗位
 选择韩国留学时，勿仅看入学政策，更要提前了解毕业后的职业发展瓶颈与薪资现实。
-**[原文 →](https://36kr.com/newsflashes/3814100578246405?f=rss)** The PIE News
+**[原文 →](https://thepienews.com/koreas-international-students-strapped-with-low-paid-jobs/)** The PIE News
 
 ### 4. 芝加哥大学对家庭收入低于25万美元学生免学费
 家庭年收入在25万美元以下的留学生可重点关注芝大，该项政策可能大幅减轻经济负担。
-**[原文 →](https://thepienews.com/koreas-international-students-strapped-with-low-paid-jobs/)** Inside Higher Ed
 
 ### 5. 我国加力优化离境退税措施扩大入境消费
 在华留学生及家长应关注离境退税便利化新政，购物消费时可享受更顺畅的退税体验。
-**[原文 →](https://www.highereddive.com/news/how-can-colleges-teach-students-to-have-challenging-conversations/820001/)** 36氪
+**[原文 →](https://36kr.com/newsflashes/3814100578246405?f=rss)** 36氪

--- a/content/coffee/2026-05-19.mdx
+++ b/content/coffee/2026-05-19.mdx
@@ -20,12 +20,9 @@ published: true
 
 ### 3. 英国OIA简化流程导致学生程序性权利流失
 在英留学生遇到学术或行政纠纷时，需了解OIA新规，保留完整证据并及时寻求专业帮助。
-**[原文 →](https://universitybusiness.com/hampshire-college-graduates-reflect-on-their-time-as-last-graduating-class/)** Wonkhe
 
 ### 4. 美最高法院将裁定大学员工能否获Title IX起诉资格
 赴美留学生应关注校园法律环境与反歧视政策变化，熟悉自身可用的维权渠道与资源。
-**[原文 →](https://wonkhe.com/blogs/higher-education-postcard-the-radcliffe-camera/)** Higher Ed Dive
 
 ### 5. 高校难以轻易弃用Canvas学习管理系统
 留学生需尽快熟练使用所在学校指定的学习管理系统，以保障选课、作业与师生互动顺畅。
-**[原文 →](https://thepienews.com/more-than-just-a-study-destination-malaysia-is-a-second-home/)** Inside Higher Ed

--- a/content/coffee/2026-05-20.mdx
+++ b/content/coffee/2026-05-20.mdx
@@ -20,12 +20,11 @@ published: true
 
 ### 3. 马拉拉呼吁部长紧急行动：1.22亿女童仍失学
 选校时可关注目的国在提升教育公平和女性赋能方面的举措。
-**[原文 →](https://universitybusiness.com/earlier-launch-policy-shifts-fuel-historic-fafsa-rebound/)** The PIE News
+**[原文 →](https://thepienews.com/malala-seeks-urgent-action-from-ministers-on-girls-education-gap/)** The PIE News
 
 ### 4. 韩国71%打工国际学生困于低薪食宿岗位
 赴韩留学前需调查打工政策与工作机会是否存在学历错配风险。
-**[原文 →](https://monitor.icef.com/2026/05/how-new-ideas-about-access-to-university-are-dramatically-expanding-the-market-for-international-higher-education/)** The PIE News
 
 ### 5. 入学人数翻倍：新理念正急剧扩大国际高教市场
 家长可利用全球高教扩张期，捕捉新兴留学目的地和多元升学路径。
-**[原文 →](https://thepienews.com/malala-seeks-urgent-action-from-ministers-on-girls-education-gap/)** ICEF Monitor
+**[原文 →](https://monitor.icef.com/2026/05/how-new-ideas-about-access-to-university-are-dramatically-expanding-the-market-for-international-higher-education/)** ICEF Monitor

--- a/content/coffee/2026-05-21.mdx
+++ b/content/coffee/2026-05-21.mdx
@@ -16,16 +16,15 @@ published: true
 
 ### 2. 英国大学国际生入学人数将再降，去年已下滑6%
 申请英国的学生需更早提交签证材料，注意政策变动对毕业生工签门槛可能产生的影响。
-**[原文 →](https://www.highereddive.com/news/university-michigan-buy-campus-concordia-university/820668/)** ICEF Monitor
+**[原文 →](https://monitor.icef.com/2026/05/uk-universities-bracing-for-a-further-decline-in-international-enrolments/)** ICEF Monitor
 
 ### 3. 澳大利亚下令暂停新职业培训及语言机构注册一年
 有意赴澳读职业课程或语言的学生应优先选择已注册且信誉良好的机构，避开新设不稳定学校。
-**[原文 →](https://www.highereddive.com/news/baldwin-wallace-university-winds-down-16-degree-programs-19-minors/820768/)** ICEF Monitor
 
 ### 4. 美国鲍德温华莱士大学砍掉16个学位及19个辅修专业
 美本选校时需关注院校专业调整动态，优先考虑投入增长型学科以保障学位含金量。
-**[原文 →](https://monitor.icef.com/2026/05/uk-universities-bracing-for-a-further-decline-in-international-enrolments/)** Higher Ed Dive
+**[原文 →](https://www.highereddive.com/news/baldwin-wallace-university-winds-down-16-degree-programs-19-minors/820768/)** Higher Ed Dive
 
 ### 5. 密歇根大学拟以6000万美元收购缩减办学的路德宗学院校区
 关注海外院校并购动向，校区转手可能影响在读生学习资源，择校时可考察学校财务稳定性。
-**[原文 →](https://www.insidehighered.com/news/admissions/traditional-age/2026/05/20/ieca-leaders-discuss-college-consulting-ai-era)** Higher Ed Dive
+**[原文 →](https://www.highereddive.com/news/university-michigan-buy-campus-concordia-university/820668/)** Higher Ed Dive

--- a/content/coffee/2026-05-22.mdx
+++ b/content/coffee/2026-05-22.mdx
@@ -16,15 +16,12 @@ published: true
 
 ### 2. 德国总理因社会气候质疑赴美留学安全性
 多国学子需平衡地缘政治风险，同时准备英加等替代方案
-**[原文 →](https://universitybusiness.com/here-are-states-3-highest-priorities-in-developing-ai-policy/)** The PIE News
 
 ### 3. 国际学生热潮终结英国正以隐形方式削减
 英国留学政策不确定性增加，建议关注专业选择及毕业后工签动态
-**[原文 →](https://universitybusiness.com/earlier-launch-policy-shifts-fuel-historic-fafsa-rebound/)** Wonkhe
 
 ### 4. 新数据预示加拿大留学吸引力正在回升
 加拿大留学竞争或将加剧，申请需尽早规划语言与资金准备
-**[原文 →](https://36kr.com/p/3819709302329735?f=rss)** ICEF Monitor
 
 ### 5. 英大臣盛赞英语教学业界敦促政策勿停滞
 选择英国语言课程时，确认学校资质和签证政策稳定性至关重要

--- a/content/coffee/2026-05-24.mdx
+++ b/content/coffee/2026-05-24.mdx
@@ -16,15 +16,13 @@ published: true
 
 ### 2. 国际学生潮终结：隐秘的政策紧缩正在上演
 留学家庭应关注目的国签证与工签隐性收紧信号，早做准备。
-**[原文 →](https://monitor.icef.com/2026/05/unesco-confirms-growing-trend-of-intra-regional-student-mobility/)** Wonkhe
 
 ### 3. 搜索数据显示加拿大留学需求回暖，吸引力回升
 有意加拿大留学的家庭可趁回暖初期抢占申请先机。
-**[原文 →](https://universitybusiness.com/here-are-states-3-highest-priorities-in-developing-ai-policy/)** ICEF Monitor
 
 ### 4. UNESCO报告：区域内学生流动增长趋势显著
 留学规划可考虑亚洲邻国优质院校，体验相近文化且成本更低。
-**[原文 →](https://36kr.com/newsflashes/3821608123027843?f=rss)** ICEF Monitor
+**[原文 →](https://monitor.icef.com/2026/05/unesco-confirms-growing-trend-of-intra-regional-student-mobility/)** ICEF Monitor
 
 ### 5. 英国技能部长称英语教学是国际教育重要一环
 关注英国语言课程政策变动，可能影响短期游学与英语进修计划。

--- a/content/coffee/2026-05-25.mdx
+++ b/content/coffee/2026-05-25.mdx
@@ -16,16 +16,15 @@ published: true
 
 ### 2. 美国联邦政府迈出认证改革重要一步
 美国高校认证标准面临重塑，留学生择校时应关注院校认证动态与含金量变化
-**[原文 →](https://36kr.com/newsflashes/3823949346787461?f=rss)** University Business
+**[原文 →](https://universitybusiness.com/feds-take-a-big-step-in-overhauling-college-accreditation/)** University Business
 
 ### 3. 教育部拟同意设置34所本科高校，22所为职业本科
 职业本科大幅扩容，家长可引导孩子关注新增院校的特色专业与技能导向培养
-**[原文 →](https://36kr.com/newsflashes/3823974426202242?f=rss)** 芥末堆
+**[原文 →](https://www.jiemodui.com/N/139388.html)** 芥末堆
 
 ### 4. 英国OIA简化申诉流程致学生程序性权利受损
 在英国发生学业纠纷时，家长应协助学生完整收集证据并熟悉OIA申诉新规
-**[原文 →](https://universitybusiness.com/feds-take-a-big-step-in-overhauling-college-accreditation/)** Wonkhe
 
 ### 5. 智能戒指厂商Oura在美秘密提交上市申请，营收四年增四倍
 健康监测设备可能进入学生日常，留意孩子隐私数据与校园健康管理结合的趋势
-**[原文 →](https://www.jiemodui.com/N/139388.html)** 36氪
+**[原文 →](https://36kr.com/newsflashes/3823949346787461?f=rss)** 36氪

--- a/content/coffee/2026-05-26.mdx
+++ b/content/coffee/2026-05-26.mdx
@@ -12,20 +12,19 @@ published: true
 
 ### 1. 国际学生繁荣期终结：政策收紧正悄然终结留学热
 留学家庭需提前关注目的国签证与移民政策风向，避免临近申请季才发现路径收窄。
-**[原文 →](https://monitor.icef.com/2026/05/unesco-confirms-growing-trend-of-intra-regional-student-mobility/)** Wonkhe
+**[原文 →](https://wonkhe.com/blogs/the-international-student-boom-is-over-and-the-bust-is-being-delivered-by-stealth/)** Wonkhe
 
 ### 2. 联合国教科文组织确认区域内留学流动趋势加速
 家长可同步考察区域内的优质院校，其性价比与就业便利性正在迅速提升。
-**[原文 →](https://universitybusiness.com/here-are-states-3-highest-priorities-in-developing-ai-policy/)** ICEF Monitor
+**[原文 →](https://monitor.icef.com/2026/05/unesco-confirms-growing-trend-of-intra-regional-student-mobility/)** ICEF Monitor
 
 ### 3. 英国技能大臣赞赏语言教育，行业敦促政策勿停滞
 计划赴英读语言课程的留学生应紧盯政策时效，尽早利用当前仍较友好的窗口期。
-**[原文 →](https://www.highereddive.com/news/university-michigan-buy-campus-concordia-university/820668/)** The PIE News
+**[原文 →](https://thepienews.com/jacqui-smith-hails-uk-elt-as-english-uk-warns-policy-progress-must-not-stall/)** The PIE News
 
 ### 4. ICEF播客：学生流向正在转移，留学机构是否跟上步伐
 选择留学中介时，应考察其对新兴目的国与政策变化的实时跟进能力。
-**[原文 →](https://thepienews.com/jacqui-smith-hails-uk-elt-as-english-uk-warns-policy-progress-must-not-stall/)** ICEF Monitor
 
 ### 5. 密歇根大学拟以6000万美元收购缩减办学的路德学院校园
 选校时需评估院校财务状况，避免因院校关闭或削减影响学业。
-**[原文 →](https://wonkhe.com/blogs/the-international-student-boom-is-over-and-the-bust-is-being-delivered-by-stealth/)** Higher Ed Dive
+**[原文 →](https://www.highereddive.com/news/university-michigan-buy-campus-concordia-university/820668/)** Higher Ed Dive

--- a/content/coffee/2026-05-27.mdx
+++ b/content/coffee/2026-05-27.mdx
@@ -20,12 +20,10 @@ published: true
 
 ### 3. 佛大公开抨击DEI为歧视，校长唯一候选人引发审视
 美国大学DEI政策快速变化，关注其对校园氛围与学生体验的实质影响
-**[原文 →](https://www.highereddive.com/news/biggest-donations-gifts-colleges-universities-2026/821000/)** University Business
 
 ### 4. 重建高等教育以恢复公众信任的路径探讨
 家长可结合高校改革方向，筛选治理透明、口碑稳健的院校
-**[原文 →](https://www.insidehighered.com/news/student-success/college-experience/2026/05/26/inside-college-housing-lifeline-bronx)** Higher Ed Dive
 
 ### 5. 2026年迄今最大高校捐赠榜单出炉
 大额捐赠凸显院校资源实力，选校时可留意资金重点投入领域
-**[原文 →](https://wonkhe.com/blogs/making-sense-of-higher-education-means-looking-at-the-whole-picture-not-just-your-corner-of-it/)** Higher Ed Dive
+**[原文 →](https://www.highereddive.com/news/biggest-donations-gifts-colleges-universities-2026/821000/)** Higher Ed Dive

--- a/content/coffee/2026-05-28.mdx
+++ b/content/coffee/2026-05-28.mdx
@@ -12,19 +12,19 @@ published: true
 
 ### 1. 美国新规：国际学生必须离境申请绿卡
 计划留美发展的家庭需重新评估身份转换路径，提早规划离境申请可能带来的时间与生活成本。
-**[原文 →](https://monitor.icef.com/2026/05/uk-sponsored-study-visa-issuances-down-rejection-rates-up-and-more/)** The PIE News
+**[原文 →](https://thepienews.com/international-students-must-leave-us-to-apply-for-green-card/)** The PIE News
 
 ### 2. 英国担保学习签证签发量下降，拒签率上升
 申请英国签证前务必严格审核材料完整性，关注官方拒签理由以降低被拒风险。
-**[原文 →](https://thepienews.com/bca-blind-spot-as-admin-review-backlog-reaches-six-months/)** ICEF Monitor
+**[原文 →](https://monitor.icef.com/2026/05/uk-sponsored-study-visa-issuances-down-rejection-rates-up-and-more/)** ICEF Monitor
 
 ### 3. 英国签证行政审查积压达六个月，形成评级盲区
 已获录取的学生应尽早提交签证申请，预留充足时间应对审查延迟。
-**[原文 →](https://monitor.icef.com/2026/05/unesco-confirms-growing-trend-of-intra-regional-student-mobility/)** The PIE News
+**[原文 →](https://thepienews.com/bca-blind-spot-as-admin-review-backlog-reaches-six-months/)** The PIE News
 
 ### 4. 教科文组织确认区域内留学生流动增长趋势
 家长可将目光扩展至教育质量提升的亚洲及新兴区域国家，就近享受优质国际化教育。
-**[原文 →](https://thepienews.com/international-students-must-leave-us-to-apply-for-green-card/)** ICEF Monitor
+**[原文 →](https://monitor.icef.com/2026/05/unesco-confirms-growing-trend-of-intra-regional-student-mobility/)** ICEF Monitor
 
 ### 5. 佛罗里达预算协议将削减顶尖公立大学额外拨款
 择校时需关注目标公立大学的财政健康状况，预算削减可能间接影响教学资源与学生支持服务。

--- a/content/coffee/2026-05-29.mdx
+++ b/content/coffee/2026-05-29.mdx
@@ -12,15 +12,15 @@ published: true
 
 ### 1. AI冲击初级岗位，应届生忧工作被取代，高校应对不足
 留学生选专业时需注重AI技能融合，避免被自动化淘汰。
-**[原文 →](https://universitybusiness.com/why-families-are-applying-early-decision-to-their-second-choice/)** University Business
+**[原文 →](https://universitybusiness.com/ai-is-breaking-the-entry-level-job-ladder-colleges-may-not-be-ready/)** University Business
 
 ### 2. 为何美国家庭纷纷在早申中瞄准第二志愿
 早申策略需调整，家长应优先考虑匹配度而非排名。
-**[原文 →](https://universitybusiness.com/ai-is-breaking-the-entry-level-job-ladder-colleges-may-not-be-ready/)** University Business
+**[原文 →](https://universitybusiness.com/why-families-are-applying-early-decision-to-their-second-choice/)** University Business
 
 ### 3. 英国签证延迟与CAS撤销重创巴基斯坦留学市场
 申请英国签证务必提前准备完备材料，警惕政策变动。
-**[原文 →](https://wonkhe.com/blogs/whats-in-alan-milburns-neet-report-for-the-higher-education-sector/)** The PIE News
+**[原文 →](https://thepienews.com/youre-not-in-good-hands-delays-and-cas-withdrawals-are-crushing-the-pakistani-market/)** The PIE News
 
 ### 4. 国际教育成中英合作核心，首届商业奖举行
 中英教育交流回暖，留学生可关注后续政策利好。
@@ -28,4 +28,3 @@ published: true
 
 ### 5. 美国教育部预测：近20万人将获劳动力佩尔助学金
 关注佩尔助学金扩展，美国职业培训成本有望降低。
-**[原文 →](https://thepienews.com/youre-not-in-good-hands-delays-and-cas-withdrawals-are-crushing-the-pakistani-market/)** Inside Higher Ed

--- a/content/coffee/2026-06-03.mdx
+++ b/content/coffee/2026-06-03.mdx
@@ -20,12 +20,10 @@ published: true
 
 ### 3. 日本本土英语课程兴起压制留学外流
 赴日留学生家庭可优先评估本土优质英语课程替代方案，降低留学成本与风险
-**[原文 →](https://www.highereddive.com/news/florida-budget-deal-would-cut-extra-funding-to-top-public-universities/821298/)** ICEF Monitor
 
 ### 4. 佛州预算案削减顶尖公立大学专项拨款
 申请佛州公立大学的学生需重新评估分校归属变动对学位认可度与资源分配的影响
-**[原文 →](https://www.highereddive.com/news/hilton-launches-undergraduate-brand-college-markets/821804/)** Higher Ed Dive
+**[原文 →](https://www.highereddive.com/news/florida-budget-deal-would-cut-extra-funding-to-top-public-universities/821298/)** Higher Ed Dive
 
 ### 5. 高途2026年Q1大学生业务收入增超20%
 国内考研与考公竞争加剧背景下，家长可关注头部机构AI赋能的精准备考服务
-**[原文 →](https://www.insidehighered.com/news/institutions/religious-colleges/2026/06/02/another-megachurch-open-college)** 芥末堆

--- a/content/coffee/2026-06-04.mdx
+++ b/content/coffee/2026-06-04.mdx
@@ -20,7 +20,7 @@ published: true
 
 ### 3. 英高校在英或海外TNE在读生成关键生源池
 已在英国读预科或通过中外合作项目学习的学生，应重点咨询本校升学通道与签证衔接方案
-**[原文 →](https://universitybusiness.com/big-ten-sec-say-they-dont-support-protect-college-sports-act-in-current-form/)** ICEF Monitor – Market intelligence for international student recruitment
+**[原文 →](https://monitor.icef.com/2026/06/report-international-students-already-studying-in-the-uk-or-offshore-through-tne-represent-an-increasingly-important-recruitment-opportunity/)** ICEF Monitor – Market intelligence for international student recruitment
 
 ### 4. 酒店管理教育成AI时代就业抗压首选
 倾向实践型专业的留学生可优先考虑带强制实习、本地就业支持强的酒店管理课程
@@ -28,4 +28,3 @@ published: true
 
 ### 5. 亚利桑那州立大学因DEI政策遭司法部调查
 申请美国高校的家庭需审阅该校近年DEI政策调整及法律纠纷记录，评估潜在就读环境稳定性
-**[原文 →](https://monitor.icef.com/2026/06/report-international-students-already-studying-in-the-uk-or-offshore-through-tne-represent-an-increasingly-important-recruitment-opportunity/)** Higher Ed Dive - Latest News

--- a/content/coffee/2026-06-05.mdx
+++ b/content/coffee/2026-06-05.mdx
@@ -28,4 +28,3 @@ published: true
 
 ### 5. 6.7万份调研揭示留学意向与实际入学落差
 家长应在高中阶段即启动财务规划与语言备考，避免因单项短板错失录取窗口期
-**[原文 →](https://universitybusiness.com/americans-looking-for-proof-in-the-value-of-higher-ed/)** ICEF Monitor – Market intelligence for international student recruitment

--- a/content/coffee/2026-06-06.mdx
+++ b/content/coffee/2026-06-06.mdx
@@ -20,12 +20,10 @@ published: true
 
 ### 3. 特朗普政府将个案施压升级为全美高校新规
 2025–2026学年赴美高校就读须提前核查校方在DEI、外国资金披露等新规下的合规状态
-**[原文 →](https://36kr.com/newsflashes/3840177808460039?f=rss)** University Business
+**[原文 →](https://universitybusiness.com/trump-officials-went-after-dozens-of-colleges-now-theyre-rewriting-the-rules-for-all-of-academia/)** University Business
 
 ### 4. 英国收紧国际招生监管，TNE与在英生源成新重点
 已入读英国TNE项目或在英就读的学生，转申本校学位课程将获优先通道与签证支持
-**[原文 →](https://universitybusiness.com/trump-officials-went-after-dozens-of-colleges-now-theyre-rewriting-the-rules-for-all-of-academia/)** ICEF Monitor – Market intelligence for international student recruitment
 
 ### 5. 2025年美国英语培训周数下降近8%
 计划赴美读语言课的学生宜优先选择有双录取保障、且2025年招生稳定的IEP项目
-**[原文 →](https://www.highereddive.com/news/university-maryland-lays-off-84-employees-budget-pressures/822073/)** ICEF Monitor – Market intelligence for international student recruitment

--- a/content/coffee/2026-06-07.mdx
+++ b/content/coffee/2026-06-07.mdx
@@ -20,12 +20,11 @@ published: true
 
 ### 3. 英国UKVI新学生担保制度正式实施
 申请英国院校前务必确认该校已获UKVI最新担保资质，避免签证申请被拒。
-**[原文 →](https://wonkhe.com/blogs/higher-education-postcard-the-school-of-slavonic-and-east-european-studies/)** Wonkhe
 
 ### 4. 美联邦法官裁定内布拉斯加州取消非公民州内学费
 有意申请内布拉斯加高校的家庭需立即重估学费预算，优先考虑提供州内费率的其他州立大学。
-**[原文 →](https://www.jiemodui.com/N/139405.html)** Inside Higher Ed
+**[原文 →](https://www.insidehighered.com/news/quick-takes/2026/06/05/federal-judge-ends-state-tuition-nebraska-noncitizens)** Inside Higher Ed
 
 ### 5. 高途2026年Q1大学生业务收入增超20%
 国内升学备考家庭可关注AI个性化课程进度追踪功能，提升复习效率与目标院校匹配度。
-**[原文 →](https://www.insidehighered.com/news/quick-takes/2026/06/05/federal-judge-ends-state-tuition-nebraska-noncitizens)** 芥末堆
+**[原文 →](https://www.jiemodui.com/N/139405.html)** 芥末堆

--- a/content/coffee/2026-06-08.mdx
+++ b/content/coffee/2026-06-08.mdx
@@ -24,8 +24,6 @@ published: true
 
 ### 4. 英国收紧国际招生监管，TNE与在英学生成关键增量来源
 申请英国TNE合作项目或已在英就读者，转学/升学路径更稳且受政策倾斜
-**[原文 →](https://www.highereddive.com/news/university-maryland-lays-off-84-employees-budget-pressures/822073/)** ICEF Monitor – Market intelligence for international student recruitment
 
 ### 5. 2025年美国英语培训周数同比下滑近8%
 语言先修路径收窄，建议优先锁定提供双录取或内测直录的美校
-**[原文 →](https://www.highereddive.com/news/hilton-launches-undergraduate-brand-college-markets/821804/)** ICEF Monitor – Market intelligence for international student recruitment

--- a/content/coffee/2026-06-09.mdx
+++ b/content/coffee/2026-06-09.mdx
@@ -24,8 +24,7 @@ published: true
 
 ### 4. 特朗普10万美元H-1B签证费被法院驳回
 有意留美就业的家庭可暂缓观望H-1B成本变化，但需关注后续替代性收费提案
-**[原文 →](https://universitybusiness.com/millions-attend-california-community-colleges-far-fewer-make-it-to-a-four-year-university/)** Higher Ed Dive - Latest News
+**[原文 →](https://www.highereddive.com/news/trumps-100k-fee-h1b-visas-struck-down/822309/)** Higher Ed Dive - Latest News
 
 ### 5. 6.7万 prospective学生调研：兴趣与实际留学差距显著
 家长应及早介入选校与申请流程，弥补信息断层，避免意向流失于执行环节
-**[原文 →](https://www.highereddive.com/news/trumps-100k-fee-h1b-visas-struck-down/822309/)** ICEF Monitor – Market intelligence for international student recruitment

--- a/content/coffee/2026-06-10.mdx
+++ b/content/coffee/2026-06-10.mdx
@@ -20,12 +20,9 @@ published: true
 
 ### 3. 英收紧国际生合规监管启用红黄绿分级
 在英就读或参与中外合作办学项目的学生，可优先把握本地升学与签证续期政策红利
-**[原文 →](https://universitybusiness.com/both-democrats-and-republicans-give-millions-to-universities-in-earmarks-but-not-in-the-same-way/)** ICEF Monitor – Market intelligence for international student recruitment
 
 ### 4. 美国英语培训周数2025年降近8%
 有意通过语言课衔接美本/美研的学生，需提前锁定优质IEP项目并关注学时认证有效性
-**[原文 →](https://monitor.icef.com/2026/06/report-international-students-already-studying-in-the-uk-or-offshore-through-tne-represent-an-increasingly-important-recruitment-opportunity/)** ICEF Monitor – Market intelligence for international student recruitment
 
 ### 5. 高途Q1大学生业务收入增超20%
 考研、考公及职业资格备考家庭可重点关注AI助学工具的实际提分效果与服务适配性
-**[原文 →](https://wonkhe.com/blogs/higher-education-postcard-the-school-of-slavonic-and-east-european-studies/)** 芥末堆

--- a/content/coffee/2026-06-11.mdx
+++ b/content/coffee/2026-06-11.mdx
@@ -24,8 +24,7 @@ published: true
 
 ### 4. 6.7万 prospective学生调研揭示留学意向与实际入学落差
 中介与校方需重点优化费用透明度和签证指导，否则超六成高意向学生将流失。
-**[原文 →](https://universitybusiness.com/college-applicants-are-now-more-reluctant-to-report-their-race/)** ICEF Monitor – Market intelligence for international student recruitment
+**[原文 →](https://monitor.icef.com/2026/06/survey-of-67000-prospective-students-highlights-gaps-between-interest-and-enrolment-for-study-abroad/)** ICEF Monitor – Market intelligence for international student recruitment
 
 ### 5. 美国教授协会调查德州高校学术自由与共治机制
 计划赴德州留学的学生及家长应关注院校AAUP认证状态，其直接关联课程稳定性与教师话语权。
-**[原文 →](https://monitor.icef.com/2026/06/survey-of-67000-prospective-students-highlights-gaps-between-interest-and-enrolment-for-study-abroad/)** Inside Higher Ed

--- a/content/coffee/2026-06-13.mdx
+++ b/content/coffee/2026-06-13.mdx
@@ -16,16 +16,15 @@ published: true
 
 ### 2. 巴西留学需求强劲但价格敏感度达78%
 计划赴英美澳的巴西家庭需优先比价+锁定汇率对冲方案，2026年秋季申请宜提前3个月启动预算规划。
-**[原文 →](https://universitybusiness.com/loan-caps-bring-both-opportunity-and-crisis-to-higher-ed/)** ICEF Monitor – Market intelligence for international student recruitment
+**[原文 →](https://monitor.icef.com/2026/06/brazil-new-surveys-show-strong-but-price-sensitive-demand-for-study-abroad/)** ICEF Monitor – Market intelligence for international student recruitment
 
 ### 3. 苏塞克斯大学胜诉OfS，监管文化或将转向
 英国院校合作方需重新评估合规成本与自主权边界，中国合作办学项目应关注2026年秋起新监管指引动向。
-**[原文 →](https://www.highereddive.com/news/marshall-university-cut-7-programs-expand-others/822707/)** Wonkhe
+**[原文 →](https://wonkhe.com/blogs/what-changes-in-regulatory-culture-might-follow-from-the-university-of-sussexs-high-court-victory-over-ofs/)** Wonkhe
 
 ### 4. 美国多所高校遭Canvas同源黑客攻击
 留学生务必启用双重验证并定期检查成绩单/注册系统异常，2026年秋季选校时应核查该校近三年网络安全审计报告。
-**[原文 →](https://monitor.icef.com/2026/06/brazil-new-surveys-show-strong-but-price-sensitive-demand-for-study-abroad/)** Higher Ed Dive - Latest News
 
 ### 5. 联邦助学贷款新上限引发院校分化危机
 依赖贷款的国际本科生需在6月底前完成FAFSA并同步申请校级奖学金，避免9月注册时资金链断裂。
-**[原文 →](https://wonkhe.com/blogs/what-changes-in-regulatory-culture-might-follow-from-the-university-of-sussexs-high-court-victory-over-ofs/)** University Business
+**[原文 →](https://universitybusiness.com/loan-caps-bring-both-opportunity-and-crisis-to-higher-ed/)** University Business

--- a/content/coffee/2026-06-14.mdx
+++ b/content/coffee/2026-06-14.mdx
@@ -20,12 +20,12 @@ published: true
 
 ### 3. 哥伦比亚留学需长期驻点+家长沟通
 瞄准哥伦比亚市场的机构须在波哥大设常驻办公室，并每季度向家长提供双语升学进展简报
-**[原文 →](https://thepienews.com/watch-ronny-chiengs-harvard-graduation-address/)** ICEF Monitor – Market intelligence for international student recruitment
+**[原文 →](https://monitor.icef.com/2026/06/recruiting-in-colombia-demands-a-long-term-presence-and-communication-with-parents/)** ICEF Monitor – Market intelligence for international student recruitment
 
 ### 4. AI时代中国留学生就业白皮书发布
 中国留学生需在本科阶段叠加AI工具开发认证与跨文化项目管理经验，而非仅依赖名校学历背书
-**[原文 →](https://monitor.icef.com/2026/06/recruiting-in-colombia-demands-a-long-term-presence-and-communication-with-parents/)** 36氪
+**[原文 →](https://36kr.com/p/3846972367866119?f=rss)** 36氪
 
 ### 5. 哈佛毕业演讲引热议
 留学生家长应引导孩子关注海外高校公共话语空间，将毕业典礼等仪式转化为批判性思辨训练场景
-**[原文 →](https://36kr.com/p/3846972367866119?f=rss)** The PIE News
+**[原文 →](https://thepienews.com/watch-ronny-chiengs-harvard-graduation-address/)** The PIE News

--- a/content/coffee/2026-06-15.mdx
+++ b/content/coffee/2026-06-15.mdx
@@ -16,16 +16,15 @@ published: true
 
 ### 2. 巴西留学需求强劲但价格敏感度达72%
 面向巴西市场的院校应优先配置本地化学费分期选项和实时汇率对冲说明。
-**[原文 →](https://universitybusiness.com/loan-caps-bring-both-opportunity-and-crisis-to-higher-ed/)** ICEF Monitor – Market intelligence for international student recruitment
+**[原文 →](https://monitor.icef.com/2026/06/brazil-new-surveys-show-strong-but-price-sensitive-demand-for-study-abroad/)** ICEF Monitor – Market intelligence for international student recruitment
 
 ### 3. 美国高校贷款新上限引发招生与财政双重压力
 家庭年收入低于8.5万美元的家庭需立即规划替代融资路径，如校内勤工俭学+微证书加速就业组合。
-**[原文 →](https://www.highereddive.com/news/marshall-university-cut-7-programs-expand-others/822707/)** University Business
+**[原文 →](https://universitybusiness.com/loan-caps-bring-both-opportunity-and-crisis-to-higher-ed/)** University Business
 
 ### 4. 马歇尔大学削减7个专业并扩大STEM与护理方向
 有意申请该校的学生应避开已宣布关停专业，优先关注其新增带临床实习的护理加速通道。
-**[原文 →](https://monitor.icef.com/2026/06/brazil-new-surveys-show-strong-but-price-sensitive-demand-for-study-abroad/)** Higher Ed Dive - Latest News
+**[原文 →](https://www.highereddive.com/news/marshall-university-cut-7-programs-expand-others/822707/)** Higher Ed Dive - Latest News
 
 ### 5. Canvas黑客组织攻击多所美高校信息系统
 留学生登录校园系统后应立即启用两步验证，并核查近30天内是否有异常成绩单或课程变更记录。
-**[原文 →](https://universitybusiness.com/can-microcredentials-drive-new-demand-for-higher-ed/)** Higher Ed Dive - Latest News

--- a/content/coffee/2026-06-16.mdx
+++ b/content/coffee/2026-06-16.mdx
@@ -24,8 +24,7 @@ published: true
 
 ### 4. 印度缺返国人才承接基础设施
 赴印求职留学生家长应提前联系本地校友网络与行业协会，规避政策落地滞后风险
-**[原文 →](https://universitybusiness.com/the-presidents-daring-to-break-the-mold-for-workforce-innovation/)** The PIE News
+**[原文 →](https://thepienews.com/the-missing-infrastructure-for-indias-returning-global-talent/)** The PIE News
 
 ### 5. 哥伦比亚留学招募须长期驻地+家长沟通
 面向哥伦比亚市场的招生团队必须设立常驻办公室并开展双语家长工作坊
-**[原文 →](https://thepienews.com/the-missing-infrastructure-for-indias-returning-global-talent/)** ICEF Monitor – Market intelligence for international student recruitment

--- a/content/coffee/2026-06-17.mdx
+++ b/content/coffee/2026-06-17.mdx
@@ -28,4 +28,3 @@ published: true
 
 ### 5. 美法官叫停USCIS签证暂停令但学生仍处不确定性
 在美留学生应提前至少90天提交身份转换或延期申请，避免因行政延误影响合法居留状态
-**[原文 →](https://www.insidehighered.com/news/quick-takes/2026/06/16/st-johns-college-consolidates-presidency)** Inside Higher Ed

--- a/content/coffee/2026-06-18.mdx
+++ b/content/coffee/2026-06-18.mdx
@@ -24,8 +24,6 @@ published: true
 
 ### 4. 6500万成人成高等教育潜在生源
 成人教育市场爆发在即，家长可关注子女升学外的‘回炉’深造路径与学分认证衔接机制
-**[原文 →](https://www.highereddive.com/news/northpoint-bible-college-ends-degree-programs-after-losing-accreditation/823217/)** University Business
 
 ### 5. AI成大学生夜间‘电子校医’
 家长应引导子女善用合规AI健康工具，但需明确其不能替代线下诊疗，尤其急重症须及时送医
-**[原文 →](https://thepienews.com/who-gets-to-feel-transformed-by-study-abroad/)** 36氪

--- a/content/coffee/2026-06-19.mdx
+++ b/content/coffee/2026-06-19.mdx
@@ -16,16 +16,14 @@ published: true
 
 ### 2. 日本新规：留日就业外国毕业生须达N2日语水平
 计划留日就业的学生务必在毕业前考取JLPT N2证书，否则将无法通过在留资格更新审核
-**[原文 →](https://universitybusiness.com/the-emerging-transcript-built-for-skills-not-courses/)** ICEF Monitor – Market intelligence for international student recruitment
+**[原文 →](https://monitor.icef.com/2026/06/japan-japanese-proficiency-essential-for-foreign-graduates-staying-on-to-work/)** ICEF Monitor – Market intelligence for international student recruitment
 
 ### 3. 卢比贬值重创印度留学市场，费用上涨超25%
 印度家庭申请2025年秋季需优先锁定汇率对冲方案，并重点评估英国/加拿大公立院校的奖学金覆盖比例
-**[原文 →](https://monitor.icef.com/2026/06/japan-japanese-proficiency-essential-for-foreign-graduates-staying-on-to-work/)** The PIE News
+**[原文 →](https://thepienews.com/how-a-weaker-rupee-is-shaping-study-abroad/)** The PIE News
 
 ### 4. 英印外交官就留学生流动定调‘精准引进’
 申请英国硕士的家庭需强化学术匹配度与职业规划逻辑，避免单纯依赖语言班或预科路径
-**[原文 →](https://www.highereddive.com/news/southern-oregon-university-plan-would-cut-3-majors-roughly-66-jobs/823213/)** The PIE News
 
 ### 5. 美国教育部新增14项跨部门协议强化留学监管
 持F-1签证赴美学生须严格核查实习岗位是否在STEM-OPT清单内，避免因协议执行升级导致工作授权失效
-**[原文 →](https://thepienews.com/how-a-weaker-rupee-is-shaping-study-abroad/)** Higher Ed Dive - Latest News

--- a/content/coffee/2026-06-20.mdx
+++ b/content/coffee/2026-06-20.mdx
@@ -24,8 +24,7 @@ published: true
 
 ### 4. Beyond Belonging：学生是否感到被重视？
 择校时家长除关注排名外，应查证学校是否有独立的学生价值认同评估机制与响应流程。
-**[原文 →](https://36kr.com/newsflashes/3860793998267653?f=rss)** Inside Higher Ed
+**[原文 →](https://www.insidehighered.com/news/student-success/college-experience/2026/06/18/beyond-belonging-do-students-feel-they-matter)** Inside Higher Ed
 
 ### 5. 三所美国高校系统化解决学生基本需求
 留学生家庭需核实目标院校是否将基本需求支持纳入正式学生服务体系，而非仅依赖临时志愿项目。
-**[原文 →](https://www.insidehighered.com/news/student-success/college-experience/2026/06/18/beyond-belonging-do-students-feel-they-matter)** Inside Higher Ed

--- a/content/coffee/2026-06-21.mdx
+++ b/content/coffee/2026-06-21.mdx
@@ -24,8 +24,8 @@ published: true
 
 ### 4. 日本要求留日毕业生须达日语N2
 计划留日就业的留学生务必在毕业前考取N2证书，否则将无法通过在留资格更新审核
-**[原文 →](https://www.highereddive.com/news/southern-oregon-university-plan-would-cut-3-majors-roughly-66-jobs/823213/)** ICEF Monitor – Market intelligence for international student recruitment
+**[原文 →](https://monitor.icef.com/2026/06/japan-japanese-proficiency-essential-for-foreign-graduates-staying-on-to-work/)** ICEF Monitor – Market intelligence for international student recruitment
 
 ### 5. 南俄勒冈大学拟裁撤3个专业
 申请该校的学生需核查目标专业是否在裁撤名单内，并评估学位认证稳定性风险
-**[原文 →](https://monitor.icef.com/2026/06/japan-japanese-proficiency-essential-for-foreign-graduates-staying-on-to-work/)** Higher Ed Dive - Latest News
+**[原文 →](https://www.highereddive.com/news/southern-oregon-university-plan-would-cut-3-majors-roughly-66-jobs/823213/)** Higher Ed Dive - Latest News

--- a/content/coffee/2026-06-22.mdx
+++ b/content/coffee/2026-06-22.mdx
@@ -28,4 +28,3 @@ published: true
 
 ### 5. 三所美院试点学生基本需求保障
 赴美就读家庭务必提前了解目标院校基本生活保障资源清单，避免入学后因经济压力中断学业。
-**[原文 →](https://www.insidehighered.com/news/student-success/college-experience/2026/06/18/beyond-belonging-do-students-feel-they-matter)** Inside Higher Ed

--- a/content/coffee/2026-06-23.mdx
+++ b/content/coffee/2026-06-23.mdx
@@ -16,16 +16,14 @@ published: true
 
 ### 2. 新生代留学生更精明：信息足、策略强、选择严
 申请季家长需协同孩子深度分析目标国就业转化率与专业匹配度，而非仅看排名
-**[原文 →](https://universitybusiness.com/here-are-the-big-advantages-of-leading-a-mid-major/)** The PIE News
+**[原文 →](https://thepienews.com/the-new-international-student-more-informed-more-strategic-more-selective/)** The PIE News
 
 ### 3. 日本新政：留日毕业生须达N2日语才可留任工作
 计划留日就业的家庭应从本科阶段起同步规划日语学习路径与等级考试时间表
-**[原文 →](https://thepienews.com/the-new-international-student-more-informed-more-strategic-more-selective/)** ICEF Monitor – Market intelligence for international student recruitment
+**[原文 →](https://monitor.icef.com/2026/06/japan-japanese-proficiency-essential-for-foreign-graduates-staying-on-to-work/)** ICEF Monitor – Market intelligence for international student recruitment
 
 ### 4. 澳大利亚教育咨询师协会AIECA正式成立
 家长委托中介前务必查验其是否已在AIECA官网注册并具备最新合规资质
-**[原文 →](https://monitor.icef.com/2026/06/japan-japanese-proficiency-essential-for-foreign-graduates-staying-on-to-work/)** The PIE News
 
 ### 5. 福耀科技大学国际研究生院成立，9月迎首批生
 有意申请中国新型应用型大学家庭，应重点关注其产教融合课程设置与企业实习配比
-**[原文 →](https://www.insidehighered.com/opinion/columns/tough-love/2026/06/22/should-we-coordinate-higher-ed-city-level-column)** 芥末堆

--- a/content/coffee/2026-06-24.mdx
+++ b/content/coffee/2026-06-24.mdx
@@ -20,7 +20,7 @@ published: true
 
 ### 3. 多所美国高校接受非学历平台学分转换
 留学生可低成本修读认证学分，但须提前确认目标院校的学分转换政策
-**[原文 →](https://www.insidehighered.com/news/quick-takes/2026/06/23/washingtons-whitman-caps-tuition-10-income)** University Business
+**[原文 →](https://universitybusiness.com/colleges-are-accepting-transfer-credits-from-online-platforms-that-arent-schools/)** University Business
 
 ### 4. ICEF白皮书：发offer后持续沟通可提升国际生转化率
 家长应提醒学生及时查收院校后续沟通，并主动索取签证、住宿等落地支持信息
@@ -28,4 +28,3 @@ published: true
 
 ### 5. 英国《高等教育治理守则》完成全面修订
 赴英就读本科或研究生的家庭应留意院校治理透明度，这关系到学术质量与学生权益保障
-**[原文 →](https://universitybusiness.com/colleges-are-accepting-transfer-credits-from-online-platforms-that-arent-schools/)** Wonkhe

--- a/content/coffee/2026-06-25.mdx
+++ b/content/coffee/2026-06-25.mdx
@@ -16,16 +16,15 @@ published: true
 
 ### 2. 荷兰国际学生注册人数首现负增长（-0.1%）
 荷兰留学热度趋缓，家长应评估其生活成本上涨与录取门槛双重压力
-**[原文 →](https://thepienews.com/international-students-intimidated-by-st-georges-flag-as-hostile-rhetoric-surges/)** ICEF Monitor – Market intelligence for international student recruitment
+**[原文 →](https://monitor.icef.com/2026/06/netherlands-reports-first-ever-decrease-in-foreign-enrolment-for-2025-26/)** ICEF Monitor – Market intelligence for international student recruitment
 
 ### 3. 英国反移民言论致留学生视圣乔治旗为敌意象征
 赴英家庭需提前了解当地社会情绪变化，重视学生心理适应支持资源
-**[原文 →](https://universitybusiness.com/100-years-ago-students-across-took-the-first-sat-where-is-it-headed-now/)** The PIE News
+**[原文 →](https://thepienews.com/international-students-intimidated-by-st-georges-flag-as-hostile-rhetoric-surges/)** The PIE News
 
 ### 4. SAT/ACT标化考试要求覆盖率跌破10%
 标化弱化不等于学术要求降低，家长应更重视GPA、课程难度与文书深度
-**[原文 →](https://monitor.icef.com/2026/06/netherlands-reports-first-ever-decrease-in-foreign-enrolment-for-2025-26/)** University Business
+**[原文 →](https://universitybusiness.com/100-years-ago-students-across-took-the-first-sat-where-is-it-headed-now/)** University Business
 
 ### 5. 福耀科技大学国际研究生院9月迎首批学生
 中国新型研究型大学加速国际化，家长可关注其产教融合特色与双导师制优势
-**[原文 →](https://www.highereddive.com/news/listen-and-learn-southern-new-hampshire-universitys-president-on-leader/823454/)** 芥末堆

--- a/content/coffee/2026-06-26.mdx
+++ b/content/coffee/2026-06-26.mdx
@@ -24,8 +24,7 @@ published: true
 
 ### 4. 英美教育需求认知偏差亟待修正
 家长选校时应核查目标校近年国际生地域分布与专业录取趋势，而非仅参考历史排名
-**[原文 →](https://universitybusiness.com/is-college-worth-it-here-are-the-majors-that-pay-off/)** The PIE News
+**[原文 →](https://thepienews.com/how-well-do-we-understand-the-demand-for-uk-international-education/)** The PIE News
 
 ### 5. 佛州拟禁止无证移民入读公立大学
 在美就读K-12的无证学生家庭需立即启动替代升学路径规划，如社区学院转学或州外私立选项
-**[原文 →](https://thepienews.com/how-well-do-we-understand-the-demand-for-uk-international-education/)** Higher Ed Dive - Latest News

--- a/content/coffee/2026-06-28.mdx
+++ b/content/coffee/2026-06-28.mdx
@@ -16,16 +16,15 @@ published: true
 
 ### 2. 阿塞拜疆大学排名跃升且学费低廉
 预算有限家庭可将阿塞拜疆纳入高性价比留学备选目的地清单
-**[原文 →](https://36kr.com/p/3867976058803459?f=rss)** ICEF Monitor – Market intelligence for international student recruitment
+**[原文 →](https://monitor.icef.com/2026/06/ascending-in-world-university-rankings-and-highly-affordable-azerbaijan-is-strengthening-its-offer-to-international-students/)** ICEF Monitor – Market intelligence for international student recruitment
 
 ### 3. 迪拜朱美拉学院校长谈未来学校
 中东优质K12国际教育正成为亚太家庭低龄留学新选项
-**[原文 →](https://monitor.icef.com/2026/06/ascending-in-world-university-rankings-and-highly-affordable-azerbaijan-is-strengthening-its-offer-to-international-students/)** The PIE News
+**[原文 →](https://thepienews.com/nicholas-brain-jumeirah-college/)** The PIE News
 
 ### 4. 澳国立大学：研究型高校标杆案例
 瞄准研究型路径的学生应重点关注ANU的本科科研孵化机制
-**[原文 →](https://thepienews.com/nicholas-brain-jumeirah-college/)** Wonkhe
+**[原文 →](https://wonkhe.com/blogs/higher-education-postcard-australian-national-university/)** Wonkhe
 
 ### 5. 联邦法院暂缓特朗普研究生贷款限制
 计划赴美读研的家庭需重新评估2026秋季起的融资方案与专业选择
-**[原文 →](https://wonkhe.com/blogs/higher-education-postcard-australian-national-university/)** University Business

--- a/content/coffee/2026-06-29.mdx
+++ b/content/coffee/2026-06-29.mdx
@@ -16,15 +16,14 @@ published: true
 
 ### 2. 荷兰国际生人数首现下降0.1%
 申请荷兰院校家庭应评估政策收紧与竞争格局变化带来的录取不确定性
-**[原文 →](https://universitybusiness.com/college-is-unaffordable-for-many-americans-but-dont-just-blame-rising-tuition/)** ICEF Monitor – Market intelligence for international student recruitment
+**[原文 →](https://monitor.icef.com/2026/06/netherlands-reports-first-ever-decrease-in-foreign-enrolment-for-2025-26/)** ICEF Monitor – Market intelligence for international student recruitment
 
 ### 3. 美大学总成本飙升超10万美元
 赴美留学家庭须按全口径成本规划预算，不可仅参考官网标价
-**[原文 →](https://thepienews.com/from-safeguarding-policy-to-safeguarding-practice-supporting-schools-through-everyday-challenges/)** University Business
+**[原文 →](https://universitybusiness.com/college-is-unaffordable-for-many-americans-but-dont-just-blame-rising-tuition/)** University Business
 
 ### 4. 福耀科技大学国际研究生院成立
 中国新兴理工类高校国际项目启动，为工科背景学生提供新路径选择
-**[原文 →](https://monitor.icef.com/2026/06/netherlands-reports-first-ever-decrease-in-foreign-enrolment-for-2025-26/)** 芥末堆
 
 ### 5. 全球南北方学生流动格局生变
 全球南方家庭申请英美加澳时需提前布局语言、资金与替代升学路径


### PR DESCRIPTION
## 背景

ai-news-bot 的一个**位置拉链 bug**（已在 ai-news-bot#8 修复代码侧）导致自 2026-04-27 起每日早咖啡 MDX 的**标题 ↔ 原文链接错配**：`poster_items`（LLM 重排/重选的 top-5）与 `top_news`（feed 原序）被按位置下标配对。`source` 署名是对的（随标题走），只有 `url` 挂错了。

明天起的新推送已是对的；本 PR 修复**历史 61 个文件**。

## 修复方式（就地语义重配对）

- 每条标题重新指向它真正描述的那篇文章的 URL，**只从该文件本身已有的 URL 池里选**（按 url slug + source 域名匹配）。
- 被原始 `top_news[:5]` 截断而丢失正确 URL 的条目（如多日的"福耀科技大学"），**删除错链**而非留着指向错文章（宁缺毋错）。
- `title_zh` / `punch` / `source` / frontmatter 全部逐字保留，只动 url 行。

## 数据

- 302 条（61 文件，4 个文件本就全对）：**99 改链 / 127 本就正确 / 76 删链**
- 校验：每条新 url 均逐字来自该文件自身 URL 池；重跑校验 **0 mismatch**
- 同域名互换对（如 04-29 两条 University Business 互换）已按位置行级编辑正确处理（首版 str.replace 会把互换还原，已发现并修正）

## 需人工复核的低置信项（数字型 slug，靠 source+排除法）

- `2026-05-12` #2、`2026-05-24` #1、`2026-05-25` #5：36氪数字 ID slug，无法读 slug 确认
- `2026-06-24` #1（惠特曼学院学费封顶）：池里有 UB 与 Inside Higher Ed 两条同主题 URL，按 source=University Business 选了 UB 版

合并即触发 Vercel 重新部署。

🤖 Generated with [Claude Code](https://claude.com/claude-code)