### PR TITLE
fix(consistency): inject company-facts ground truth into LLM judge prompt

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,6 +37,7 @@ Vercel SSG 静态部署不支持非 ASCII 文件名路由（中文 URL percent-e
 - **CI 门禁**：PR 包含博客内容变更时，`Content Consistency Check` job 自动运行
 - **自动博客**：`daily-blog.yml` 生成文章后、创建 PR 前自动检查
 - **双层检查**：第一层正则规则（快速免费）+ 第二层 LLM 语义分析（深层）
+- **事实基准**：LLM 语义检查以 `memories/company-facts.md` 为最高权威注入 prompt——不同业务主体（异乡好居/异乡缴费/异乡人才/异乡点评）的同类指标不是同一指标（2026-07-19 误报事故：好居 40 万客户 vs 缴费 18 万客户被判冲突）
 - **阻塞合并**：检查不通过时 CI 失败，PR 无法合并
 
 ### 写作时注意

--- a/scripts/check_content_consistency.py
+++ b/scripts/check_content_consistency.py
@@ -30,6 +30,7 @@ ROOT_DIR = Path(__file__).resolve().parent.parent
 BLOG_DIR = ROOT_DIR / "content" / "blog"
 FACTS_DB = ROOT_DIR / "content" / "facts.json"
 CONFIG_PATH = ROOT_DIR / "scripts" / "blog_config.yaml"
+COMPANY_FACTS_PATH = ROOT_DIR / "memories" / "company-facts.md"
 
 # --- 事实提取（正则） ---
 
@@ -149,10 +150,21 @@ def get_changed_blog_files(base: str) -> list[str]:
         return []
 
 
-def call_llm_check(new_facts: list[dict], existing_facts: list[dict], new_content: str, config: dict) -> dict:
-    """调用 LLM 进行深层语义一致性检查"""
-    provider = config.get("llm", {}).get("provider", "anthropic")
+def load_company_facts() -> str:
+    """加载事实基准（memories/company-facts.md），缺失时返回空串。
 
+    这是 LLM judge 的最高权威事实来源：没有它，judge 无法区分
+    不同业务主体的同类指标（2026-07-19 事故：把异乡好居累计客户 40 万
+    与异乡缴费缴费客户 18 万+ 判为同一指标的冲突）。
+    """
+    try:
+        return COMPANY_FACTS_PATH.read_text(encoding="utf-8")
+    except OSError:
+        return ""
+
+
+def build_llm_prompt(new_facts: list[dict], existing_facts: list[dict], new_content: str, ground_truth: str) -> str:
+    """构造 LLM 一致性审查 prompt（纯函数，便于测试）"""
     existing_summary = "\n".join(
         f"- [{f['source']}] {f['type']}: {f.get('value', '')} — {f['context']}"
         for f in existing_facts[:100]  # 限制长度
@@ -161,8 +173,20 @@ def call_llm_check(new_facts: list[dict], existing_facts: list[dict], new_conten
         f"- {f['type']}: {f.get('value', '')} — {f['context']}" for f in new_facts
     )
 
-    prompt = f"""你是一个内容一致性审查员。请检查新文章中的事实性声明是否与已有文章存在冲突。
+    ground_truth_section = ""
+    if ground_truth:
+        ground_truth_section = f"""
+## 事实基准（最高权威，用户确认的公司事实清单）
+{ground_truth}
 
+基准判定规则：
+- 上表是数字归属的最高权威。新文章的数字与基准一致且业务主体归属正确时，**不得报冲突**。
+- 异乡好居、异乡缴费、异乡人才、异乡点评是不同业务主体，**不同业务主体的同类指标（如各自的客户数）不是同一指标**，数字不同不算冲突。
+- 只有当两篇文章对**同一主体的同一指标**给出矛盾数字时才是冲突。
+"""
+
+    return f"""你是一个内容一致性审查员。请检查新文章中的事实性声明是否与已有文章存在冲突。
+{ground_truth_section}
 ## 已有文章的事实性声明
 {existing_summary}
 
@@ -178,6 +202,7 @@ def call_llm_check(new_facts: list[dict], existing_facts: list[dict], new_conten
 3. 时间线应该自洽（不能说 2024 年开始做的事情在 2023 年已经有成果）
 4. 技术栈描述应该一致（不能一篇说用 PostgreSQL，另一篇说用 MySQL）
 5. 如果数字有合理的时间推移变化（如岗位数增长），这不算冲突
+6. 判断数字是否为同一指标时，必须先确认业务主体一致；主体不同的数字不构成冲突
 
 ## 输出格式（严格 JSON）
 {{
@@ -204,6 +229,12 @@ def call_llm_check(new_facts: list[dict], existing_facts: list[dict], new_conten
 反例（禁止）：把 explanation 写成"数字一致，无冲突"却仍以 error 列入 conflicts。
 
 只输出 JSON，不要其他内容。如果没有冲突，conflicts 为空数组，pass 为 true。"""
+
+
+def call_llm_check(new_facts: list[dict], existing_facts: list[dict], new_content: str, config: dict) -> dict:
+    """调用 LLM 进行深层语义一致性检查"""
+    provider = config.get("llm", {}).get("provider", "anthropic")
+    prompt = build_llm_prompt(new_facts, existing_facts, new_content, load_company_facts())
 
     if provider == "anthropic":
         from anthropic import Anthropic

--- a/tests/test_llm_prompt_ground_truth.py
+++ b/tests/test_llm_prompt_ground_truth.py
@@ -1,0 +1,62 @@
+"""一致性检查 LLM prompt 事实基准注入测试。
+
+锁住 2026-07-19 daily-blog 失败的根因：LLM judge 不知道数字的业务主体归属
+（异乡好居累计客户 40 万 vs 异乡缴费缴费客户 18 万+，两者都是
+memories/company-facts.md 里用户确认过的真实数据），把跨主体的两个数字
+判为同一指标的冲突（error 级），阻塞了完全合规的文章。
+
+修复：build_llm_prompt 必须把 company-facts.md 作为事实基准注入 prompt，
+并明确"不同业务主体的同类指标不是同一指标"的判定规则。
+"""
+
+import scripts.check_content_consistency as cc
+
+NEW_FACTS = [
+    {"type": "number", "value": "40", "unit": "万", "context": "异乡好居服务了超过 40 万客户", "source": "new.mdx"},
+]
+EXISTING_FACTS = [
+    {"type": "number", "value": "18", "unit": "万", "context": "累计服务了超过 18 万名客户的留学缴费", "source": "old.mdx"},
+]
+
+
+def test_load_company_facts_reads_memory_file():
+    """load_company_facts 读取 memories/company-facts.md 全文。"""
+    text = cc.load_company_facts()
+    assert "40 万" in text
+    assert "异乡缴费" in text
+    assert "异乡好居" in text
+
+
+def test_load_company_facts_missing_file_returns_empty(tmp_path, monkeypatch):
+    """事实文件不存在时返回空串，不抛异常。"""
+    monkeypatch.setattr(cc, "COMPANY_FACTS_PATH", tmp_path / "nonexistent.md")
+    assert cc.load_company_facts() == ""
+
+
+def test_prompt_includes_ground_truth_and_attribution_rule():
+    """有事实基准时，prompt 必须包含基准全文和主体归属判定规则。"""
+    ground_truth = "| 客户数（累计） | 40 万 | 异乡好居 |\n| 缴费客户数（5 年） | 18 万+ | 异乡缴费 |"
+    prompt = cc.build_llm_prompt(NEW_FACTS, EXISTING_FACTS, "正文", ground_truth)
+    assert ground_truth in prompt
+    assert "事实基准" in prompt
+    # 主体归属规则：不同业务主体的同类指标不是同一指标
+    assert "不同业务主体" in prompt
+    assert "不是同一指标" in prompt or "不算冲突" in prompt
+
+
+def test_prompt_without_ground_truth_omits_section():
+    """无事实基准（文件缺失）时，prompt 不含空的基准章节，其余结构完整。"""
+    prompt = cc.build_llm_prompt(NEW_FACTS, EXISTING_FACTS, "正文", "")
+    assert "事实基准" not in prompt
+    assert "已有文章的事实性声明" in prompt
+    assert "输出格式" in prompt
+
+
+def test_prompt_still_contains_core_sections_with_ground_truth():
+    """注入基准不能破坏原有 prompt 结构（facts 摘要、正文、输出格式、伪冲突约束）。"""
+    prompt = cc.build_llm_prompt(NEW_FACTS, EXISTING_FACTS, "正文内容", "基准表")
+    assert "已有文章的事实性声明" in prompt
+    assert "40" in prompt and "18" in prompt
+    assert "正文内容" in prompt
+    assert "输出格式" in prompt
+    assert "严禁" in prompt  # 伪冲突约束仍在


### PR DESCRIPTION
## 背景

2026-07-19 的 Daily Blog Post Generator 失败（run 29667397768）：文章生成成功，但内容一致性门禁把「异乡好居服务超 40 万客户」与旧文《留学缴费的真相》里的「异乡缴费 18 万名客户」判为 error 级冲突，CI fail。

两个数字都是 `memories/company-facts.md` 里用户确认过的真实数据，主体不同（好居累计客户 40 万 / 缴费客户 18 万+），且 40 万早已出现在 `2026-03-19-wecom-vs-feishu` 一文中。这是 LLM judge 的误报。

## 根因

LLM 审查 prompt 完全没有事实基准表，judge 无法区分不同业务主体的同类指标，把跨主体数字当成了同一指标的矛盾。

## 修复

- `call_llm_check` 现在把 `memories/company-facts.md` 全文作为「事实基准（最高权威）」注入 prompt，并附判定规则：不同业务主体（好居/缴费/人才/点评）的同类指标不是同一指标
- prompt 构造抽为纯函数 `build_llm_prompt()`，事实加载抽为 `load_company_facts()`（文件缺失时优雅降级为空）
- 新增 `tests/test_llm_prompt_ground_truth.py`（5 个测试，TDD 先红后绿）
- CLAUDE.md 检查流程说明同步更新

## 验证

- `pytest tests/test_llm_prompt_ground_truth.py tests/test_consistency_eval.py` → 13 passed
- 无 key 冒烟：`check_content_consistency.py --target 2026-03-19-wecom-vs-feishu` → 通过
- 组装后的真实 prompt 含 40 万/18 万两条基准行（已断言验证）
- `tests/test_integration.py` / `test_select_topic.py` 的 5 个失败在未修改的 origin/main 上同样存在（本地 SDK 环境问题），与本 PR 无关

🤖 Generated with [Claude Code](https://claude.com/claude-code)